### PR TITLE
공통 컴포넌트 카드 및 컨테이너 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.69.0",
         "@tanstack/react-query-devtools": "^5.69.0",
+        "dayjs": "^1.11.13",
         "next": "15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -5189,6 +5190,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",
+    "dayjs": "^1.11.13",
     "next": "15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,10 @@
 'use client';
 
-import { Container } from '@/shared/components/container/Container';
-
 export default function Home() {
   return (
     <>
       <div className="flex w-full h-10 bg-sky-50">메인 홈페이지</div>
-      <div className="flex justify-center w-full">
-        <Container
-          href={'/'}
-          deadLine="2025-03-28"
-          currentParticipants={4}
-          maxParticipants={15}
-        />
-      </div>
+      <div className="flex justify-center w-full"></div>
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,19 @@
 'use client';
-import toast from 'react-hot-toast';
+
+import { Container } from '@/shared/components/container/Container';
 
 export default function Home() {
   return (
     <>
-      <div className="w-10 h-10 bg-sky-50">메인 홈페이지</div>
-      <div className="p-4">
-        <button
-          className="bg-blue-500 text-white px-4 py-2 rounded"
-          onClick={() => toast.success('성공했습니다! 🎉')}
-        >
-          성공 토스트
-        </button>
-
-        <button
-          className="bg-red-500 text-white px-4 py-2 rounded ml-2"
-          onClick={() => toast.error('문제가 생겼어요 😢')}
-        >
-          에러 토스트
-        </button>
-
-        <button
-          className="bg-gray-700 text-white px-4 py-2 rounded ml-2"
-          onClick={() => toast('그냥 일반 메시지 😎')}
-        >
-          일반 토스트
-        </button>
+      <div className="flex w-full h-10 bg-sky-50">메인 홈페이지</div>
+      <div className="flex justify-center w-full">
+        <Container
+          href={'/'}
+          deadLine="2025-03-28"
+          currentParticipants={4}
+          maxParticipants={15}
+        />
       </div>
-      );
     </>
   );
 }

--- a/src/lib/utill.ts
+++ b/src/lib/utill.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import localeData from 'dayjs/plugin/localeData';
+import 'dayjs/locale/ko';
+
+dayjs.extend(relativeTime);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(localeData);
+dayjs.locale('ko');
+
+export default dayjs;

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -51,9 +51,9 @@ const ButtonBorderStyle = {
   [ButtonBorder.LITTLE_RECTANGLE_BORDER]:
     'rounded-lg border-2 border-custom-gray-800 ',
   [ButtonBorder.RECTANGLE]: 'rounded-xl ',
-  [ButtonBorder.RECTANGLE_BORDER]: 'rounded-xl border-2 border-custom-gray-800',
+  [ButtonBorder.RECTANGLE_BORDER]: 'rounded-xl border-1 border-custom-gray-800',
   [ButtonBorder.ROUND]: 'rounded-4xl',
-  [ButtonBorder.ROUND_BORDER]: 'rounded-4xl border-2 border-custom-gray-800',
+  [ButtonBorder.ROUND_BORDER]: 'rounded-4xl border-1 border-custom-gray-800',
 };
 
 const buttonColorStyle = {
@@ -61,7 +61,7 @@ const buttonColorStyle = {
   [BGColor.YELLOW]:
     'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-yellow-brand py-2 md:py-2.5',
   [BGColor.WHITE]:
-    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-white py-3 md:py-3.5 ',
+    'text-sm  font-semibold text-nowrap text-custom-gray-800 bg-custom-white px-4 py-2 md:py-2.5 ',
   [BGColor.GRAY]:
     'text-sm md:text-base font-semibold  text-custom-gray-500 bg-custom-gray-200 py-3 md:py-3.5',
   [BGColor.DARK_GRAY]:
@@ -108,7 +108,7 @@ export default function Button({
     return (
       <Link
         href={href}
-        className={`flex gap-2  justify-center items-center ${baseStyle} ${bgColorStyle} ${borderStyle}`}
+        className={`flex gap-2 justify-center items-center ${baseStyle} ${bgColorStyle} ${borderStyle}`}
       >
         {children}
         {icon ? <Image src={iconChoice} alt="button Icon" width={16} /> : ''}

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -57,17 +57,17 @@ const ButtonBorderStyle = {
 };
 
 const buttonColorStyle = {
-  [BGColor.RED]: 'text-custom-red bg-custom-red-brand',
+  [BGColor.RED]: 'text-custom-red bg-custom-red-brand py-3 md:py-3.5',
   [BGColor.YELLOW]:
-    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-yellow-brand',
+    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-yellow-brand py-2 md:py-2.5',
   [BGColor.WHITE]:
-    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-white ',
+    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-white py-3 md:py-3.5 ',
   [BGColor.GRAY]:
-    'text-sm md:text-base font-semibold  text-custom-gray-500 bg-custom-gray-200',
+    'text-sm md:text-base font-semibold  text-custom-gray-500 bg-custom-gray-200 py-3 md:py-3.5',
   [BGColor.DARK_GRAY]:
-    'text-sm md:text-base font-bold text-custom-gray-700 bg-custom-gray-400',
+    'text-sm md:text-base font-bold text-custom-gray-700 bg-custom-gray-400 py-3 md:py-3.5',
   [BGColor.BLACK]:
-    'text-sm md:text-base font-semibold text-custom-white bg-custom-gray-800',
+    'text-sm md:text-base font-semibold text-custom-white bg-custom-gray-800 py-3 md:py-3.5',
 };
 
 const ButtonIconChoice = {
@@ -99,7 +99,7 @@ export default function Button({
   closeIcon = false,
   ...props
 }: ButtonProps) {
-  const baseStyle = 'w-full px-30 py-3 md:py-3.5 justify-center cursor-pointer';
+  const baseStyle = 'w-full  justify-center cursor-pointer';
   const bgColorStyle = buttonColorStyle[bgColor];
   const borderStyle = ButtonBorderStyle[border];
   const iconChoice = icon ? ButtonIconChoice[icon] : null;
@@ -111,7 +111,7 @@ export default function Button({
         className={`flex gap-2  justify-center items-center ${baseStyle} ${bgColorStyle} ${borderStyle}`}
       >
         {children}
-        <Image src={iconChoice} alt="button Icon" width={16} />
+        {icon ? <Image src={iconChoice} alt="button Icon" width={16} /> : ''}
       </Link>
     );
   }

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -1,0 +1,79 @@
+import timerIcon from '@images/deadLine-icon/small.svg';
+import personIcon from '@images/person-icon/small.svg';
+import Image from 'next/image';
+import selectorIcon from '@images/menu-icon/Meatballs.svg';
+import dayjs from '@/lib/utill';
+import { DocumentType, FieldType } from '@/types';
+import { Chip } from '../chip/chip';
+import Button, { BGColor, ButtonBorder, ButtonImg } from '../button/Button';
+
+export interface CardProps {
+  title: string;
+  DocumentType: DocumentType;
+  FieldType: FieldType;
+  deadLine: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  href: string;
+}
+
+export const Card = ({
+  title,
+  DocumentType,
+  FieldType,
+  deadLine,
+  currentParticipants,
+  maxParticipants,
+  href,
+}: CardProps) => {
+  const maxParticipant = maxParticipants === currentParticipants;
+
+  return (
+    <div className="flex flex-col justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 ">
+      <section className="flex justify-between relative">
+        <div className="flex flex-col gap-4 w-4xl">
+          {maxParticipant ? (
+            <div className="flex">
+              <Chip label={DocumentType} />
+            </div>
+          ) : (
+            ''
+          )}
+          <p className="text-xl text-custom-gray-700 font-bold">{title}</p>
+          <div className="flex gap-1.5 ">
+            <Chip label={FieldType} />
+            <Chip label={DocumentType} />
+          </div>
+        </div>
+        <Image
+          src={selectorIcon}
+          alt="selector Icon"
+          className="absolute right-0"
+        />
+      </section>
+
+      <section className="flex w-full justify-between pt-4  border-t border-custom-gray-200">
+        <div className="flex items-center w-full gap-1">
+          <Image src={timerIcon} alt="deadLine Icon" width={16} height={16} />
+          <p className="text-sm font-normal text-custom-gray-600">
+            {dayjs(deadLine).format('YYYY년 M월 D일')} 마감
+          </p>
+          <Image src={personIcon} alt="person Icon" width={16} height={16} />
+          <p className="text-sm font-normal text-custom-gray-600">
+            {currentParticipants}/{maxParticipants}
+          </p>
+        </div>
+        <div className="flex w-40 ">
+          <Button
+            border={ButtonBorder.ROUND_BORDER}
+            bgColor={BGColor.WHITE}
+            icon={ButtonImg.CONTINUE}
+            href={href}
+          >
+            도전 계속하기
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/shared/components/container/Container.tsx
+++ b/src/shared/components/container/Container.tsx
@@ -3,21 +3,25 @@ import personIcon from '@images/person-icon/small.svg';
 import Image from 'next/image';
 import Button, { BGColor, ButtonBorder } from '../button/Button';
 import dayjs from '@/lib/utill';
+import { ButtonHTMLAttributes } from 'react';
 
-export interface Container {
-  href: string;
+export interface ContainerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  originUrl: string;
   deadLine: string;
   currentParticipants: number;
   maxParticipants: number;
 }
 
 export const Container = ({
-  href,
+  originUrl,
   deadLine,
   currentParticipants,
   maxParticipants,
-}: Container) => {
+  ...props
+}: ContainerProps) => {
   const overDeadLine = dayjs(deadLine).isBefore(dayjs());
+  const maxParticipant = maxParticipants === currentParticipants;
 
   return (
     <div className="flex flex-col justify-center items-center rounded-2xl border-2 border-custom-gray-100 gap-4 px-4 py-6 w-96 md:w-64 xl:w-72 ">
@@ -37,7 +41,7 @@ export const Container = ({
           <Button
             border={ButtonBorder.RECTANGLE_BORDER}
             bgColor={BGColor.YELLOW}
-            href={href}
+            href={originUrl}
           >
             원본 보기
           </Button>
@@ -45,7 +49,10 @@ export const Container = ({
         <div className="flex w-40 md:w-56 xl:w-60">
           <Button
             border={ButtonBorder.RECTANGLE}
-            bgColor={overDeadLine ? BGColor.GRAY : BGColor.BLACK}
+            bgColor={
+              maxParticipant || overDeadLine ? BGColor.GRAY : BGColor.BLACK
+            }
+            {...props}
           >
             작업 도전하기
           </Button>

--- a/src/shared/components/container/Container.tsx
+++ b/src/shared/components/container/Container.tsx
@@ -1,0 +1,56 @@
+import timerIcon from '@images/deadLine-icon/small.svg';
+import personIcon from '@images/person-icon/small.svg';
+import Image from 'next/image';
+import Button, { BGColor, ButtonBorder } from '../button/Button';
+import dayjs from '@/lib/utill';
+
+export interface Container {
+  href: string;
+  deadLine: string;
+  currentParticipants: number;
+  maxParticipants: number;
+}
+
+export const Container = ({
+  href,
+  deadLine,
+  currentParticipants,
+  maxParticipants,
+}: Container) => {
+  const overDeadLine = dayjs(deadLine).isBefore(dayjs());
+
+  return (
+    <div className="flex flex-col justify-center items-center rounded-2xl border-2 border-custom-gray-100 gap-4 px-4 py-6 w-96 md:w-64 xl:w-72 ">
+      <section className="flex justify-center items-center w-full gap-1">
+        <Image src={timerIcon} alt="deadLine Icon" width={16} height={16} />
+        <p className="text-sm font-normal text-custom-gray-600">
+          {dayjs(deadLine).format('YYYY년 M월 D일')} 마감
+        </p>
+        <Image src={personIcon} alt="person Icon" width={16} height={16} />
+        <p className="text-sm font-normal text-custom-gray-600">
+          {currentParticipants}/{maxParticipants}
+        </p>
+      </section>
+
+      <section className="flex  md:flex-col md:items-center gap-1">
+        <div className="flex w-40 md:w-56 xl:w-60 ">
+          <Button
+            border={ButtonBorder.RECTANGLE_BORDER}
+            bgColor={BGColor.YELLOW}
+            href={href}
+          >
+            원본 보기
+          </Button>
+        </div>
+        <div className="flex w-40 md:w-56 xl:w-60">
+          <Button
+            border={ButtonBorder.RECTANGLE}
+            bgColor={overDeadLine ? BGColor.GRAY : BGColor.BLACK}
+          >
+            작업 도전하기
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/stories/Card.stories.ts
+++ b/src/stories/Card.stories.ts
@@ -1,0 +1,38 @@
+import { Card } from '@/shared/components/card/Card';
+import { DocumentType, FieldType } from '@/types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/card',
+  component: Card,
+  argTypes: {
+    DocumentType: {
+      control: 'select',
+      options: Object.values(DocumentType),
+    },
+    FieldType: {
+      control: 'select',
+      options: Object.values(FieldType),
+    },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const chip: Story = {
+  args: {
+    title: 'Next.js - App Router: Routing Fundamentals',
+    DocumentType: DocumentType.OFFICIAL,
+    FieldType: FieldType.NEXTJS,
+    deadLine: '2025-03-28',
+    currentParticipants: 15,
+    maxParticipants: 15,
+    href: '/',
+  },
+};

--- a/src/stories/Container.stories.ts
+++ b/src/stories/Container.stories.ts
@@ -1,0 +1,25 @@
+import { Container } from '@/shared/components/container/Container';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Container',
+  component: Container,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Container>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const chip: Story = {
+  args: {
+    originUrl: '/',
+    deadLine: '2025-03-28',
+    currentParticipants: 5,
+    maxParticipants: 15,
+    onClick: () => {},
+  },
+};


### PR DESCRIPTION
## 📌 개요

- 공통 컴포넌트 카드 및 컨테이너 구현

## ✨ 주요 변경 사항

- 공통으로 사용가능한 카드 컴포넌트를 구현했습니다.
- 공통으로 사용가능한 컨테이너 컴포넌트를 구현했습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- npm run storybook 통해서 컴포넌트를 확인할 수 있습니다!
 받은 props가 미치는 영향을 간단하게 표기하겠습니다

- Card
<필수>
title= 타이틀 텍스트를 표기해 줍니다.
DocumentType= DocumentType 따라 Chip의 스타일이 표기됩니다.
FieldType= FieldType  따라 Chip의 스타일이 표기됩니다.
deadLine= 마감기안에 표기에 영향을 줍니다..
currentParticipants= 현재 도전 인원(currentParticipants) 표기 및  최대 인원 수(maxParticipants)와 같은 경우 모집 마감 칩이 표기됩니다.
maxParticipants= 최대 인원 수(maxParticipants) 표기 및  현재 도전 인원(currentParticipants)과 같은 경우 모집 마감 칩이 표기됩니다.
href= 버튼클릭시 입력된 href 따라 이동됩니다. 

- Container
<필수>
originUrl= 테두리(Radius)에 영향을 줍니다.
deadLine= 마감기안에 표기 및 마감기간이 지난 경우 도전 버튼이 비활성화 됩니다.
currentParticipants= 현재 도전 인원(currentParticipants) 표기 및  최대 인원 수(maxParticipants)와 같은 경우 도전 버튼이 비활성화 됩니다.
maxParticipants= 최대 인원 수(maxParticipants) 표기 및  현재 도전 인원(currentParticipants)과 같은 경우 도전 버튼이 비활성화 됩니다.
<선택>
...prop = onClik과 같은 함수 및 다른 prop를 추가로 받아 올 수 있습니다.

## 🔗 관련 이슈

- 구현에 중심을 두어 props를 많이 받아와야하는 점을 고려하여 추후 리펙토링 해보겠습니다.

## 📸 스크린샷

- 카드
![카드사용 예시](https://github.com/user-attachments/assets/7a279af5-19ee-4e60-9775-5074b2b706fc)

- 컨테이너
![컨테이너 예시](https://github.com/user-attachments/assets/da7bd661-a593-4e80-90d6-cc29b46521e8)
