### PR TITLE
챌린지 목록 보기 페이지 UI구현 완료

### DIFF
--- a/src/app/main/challenge/[id]/page.tsx
+++ b/src/app/main/challenge/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from "next";
+import { NextPage } from 'next';
 const ChallengeDetail: NextPage = () => {
   return <></>;
 };

--- a/src/app/main/challenge/_components/ChallengeHead.tsx
+++ b/src/app/main/challenge/_components/ChallengeHead.tsx
@@ -1,0 +1,23 @@
+import Button, {
+  BGColor,
+  ButtonBorder,
+  ButtonImg,
+} from '@/shared/components/button/Button';
+
+export default function ChallengeHead() {
+  return (
+    <div className="flex justify-between items-center">
+      <p className="text-xl text-custom-gray-800 font-semibold ">챌린지 목록</p>
+      <div className="flex px-">
+        <Button
+          border={ButtonBorder.ROUND}
+          bgColor={BGColor.BLACK}
+          icon={ButtonImg.NEWCHALLENGE}
+          href={'/auth/login'}
+        >
+          신규 챌린지 신청
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Button, {
+  BGColor,
+  ButtonBorder,
+} from '@/shared/components/button/Button';
+import { Card, CardProps } from '@/shared/components/card/Card';
+import Search from '@/shared/components/input/search';
+import { DocumentType, FieldType } from '@/types';
+import { useState } from 'react';
+import Pagination from './Pagination';
+
+const seedData: CardProps[] = [
+  // {
+  //   title: 'Next.js로 블로그 만들기',
+  //   DocumentType: DocumentType.BLOG,
+  //   FieldType: FieldType.NEXTJS,
+  //   deadLine: '2025-04-15',
+  //   currentParticipants: 3,
+  //   maxParticipants: 5,
+  //   href: '/projects/nextjs-blog',
+  // },
+  // {
+  //   title: '모던 자바스크립트 완전 정복',
+  //   DocumentType: DocumentType.OFFICIAL,
+  //   FieldType: FieldType.MODERNJS,
+  //   deadLine: '2025-04-20',
+  //   currentParticipants: 5,
+  //   maxParticipants: 10,
+  //   href: '/projects/modernjs-master',
+  // },
+  // {
+  //   title: 'REST API 실전 프로젝트',
+  //   DocumentType: DocumentType.BLOG,
+  //   FieldType: FieldType.API,
+  //   deadLine: '2025-05-01',
+  //   currentParticipants: 2,
+  //   maxParticipants: 6,
+  //   href: '/projects/rest-api-practice',
+  // },
+];
+
+const ChallengeMain = () => {
+  const [search, setSearch] = useState('');
+
+  const handleSearch = (e: string) => {
+    setSearch(e);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 ">
+      <section className="flex gap-3">
+        <div className="flex items-center">
+          <Button
+            border={ButtonBorder.RECTANGLE_BORDER}
+            bgColor={BGColor.WHITE}
+          >
+            필터 버튼 자리
+          </Button>
+        </div>
+
+        <div className="w-full">
+          <Search
+            name={'text'}
+            placeholder="챌린지 이름을 검색해보세요"
+            onSearch={handleSearch}
+          />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-6 w-full">
+        {seedData.length === 0 ? (
+          <div className="flex h-screen justify-center items-center">
+            <p className="text-center text-gray-500">
+              아직 챌린지가 없어요.
+              <br />
+              지금 바로 챌린지를 신청해보세요!
+            </p>
+          </div>
+        ) : (
+          <>
+            {seedData.map((data, index) => (
+              <Card
+                key={index}
+                title={data.title}
+                DocumentType={data.DocumentType}
+                FieldType={data.FieldType}
+                deadLine={data.deadLine}
+                currentParticipants={data.currentParticipants}
+                maxParticipants={data.maxParticipants}
+                href={data.href}
+              />
+            ))}
+          </>
+        )}
+      </section>
+
+      {seedData.length > 0 && (
+        <section className="flex justify-center">
+          <Pagination totalPages={20} />
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default ChallengeMain;

--- a/src/app/main/challenge/_components/Pagination.tsx
+++ b/src/app/main/challenge/_components/Pagination.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import prevGray from '@images/arrow-icon/no-stick/gray.svg';
+import prevBlack from '@images/arrow-icon/no-stick/black.svg';
+
+type PaginationProps = {
+  totalPages: number;
+};
+
+const blockSize = 5;
+
+const Pagination = ({ totalPages }: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const currentBlock = Math.floor((currentPage - 1) / blockSize);
+  const startPage = currentBlock * blockSize + 1;
+  const endPage = Math.min(startPage + blockSize - 1, totalPages);
+
+  const pageNumbers = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i
+  );
+
+  const isPrevDisabled = currentPage === 1;
+  const isNextDisabled = currentPage === totalPages;
+
+  return (
+    <div className="flex w-72 md:w-80 gap-3 items-center justify-center mt-4">
+      <button
+        onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+        disabled={isPrevDisabled}
+      >
+        <Image
+          key={`${isPrevDisabled}-prev`}
+          src={isPrevDisabled ? prevGray : prevBlack}
+          alt="previous Icon"
+          width={6}
+          height={12}
+          className={isPrevDisabled ? '' : 'rotate-180'}
+        />
+      </button>
+
+      <div>
+        {pageNumbers.map((page) => (
+          <button
+            key={page}
+            onClick={() => setCurrentPage(page)}
+            className={`w-10 h-10 rounded-xl ${
+              page === currentPage
+                ? 'bg-custom-gray-800 text-sm text-custom-yellow-brand font-medium'
+                : 'bg-white text-sm text-custom-gray-400 font-medium'
+            }`}
+          >
+            {page}
+          </button>
+        ))}
+      </div>
+
+      <button
+        onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+        disabled={isNextDisabled}
+      >
+        <Image
+          key={`${isNextDisabled}-prev`}
+          src={isNextDisabled ? prevGray : prevBlack}
+          alt="next Icon"
+          width={6}
+          height={12}
+          className={isNextDisabled ? 'rotate-180' : ''}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/app/main/challenge/page.tsx
+++ b/src/app/main/challenge/page.tsx
@@ -1,6 +1,14 @@
-import { NextPage } from "next";
-const Challenge: NextPage = () => {
-  return <></>;
+import { NextPage } from 'next';
+import ChallengeHead from './_components/ChallengeHead';
+import ChallengeMain from './_components/ChallengeMain';
+
+const ChallengeDetail: NextPage = () => {
+  return (
+    <div className="flex gap-4 flex-col px-4 md:px-6 xl:px-[28.875rem] pt-20 pb-28">
+      <ChallengeHead />
+      <ChallengeMain />
+    </div>
+  );
 };
 
-export default Challenge;
+export default ChallengeDetail;

--- a/src/lib/utill.ts
+++ b/src/lib/utill.ts
@@ -1,0 +1,14 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import localeData from 'dayjs/plugin/localeData';
+import 'dayjs/locale/ko';
+
+dayjs.extend(relativeTime);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(localeData);
+dayjs.locale('ko');
+
+export default dayjs;

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -51,23 +51,23 @@ const ButtonBorderStyle = {
   [ButtonBorder.LITTLE_RECTANGLE_BORDER]:
     'rounded-lg border-2 border-custom-gray-800 ',
   [ButtonBorder.RECTANGLE]: 'rounded-xl ',
-  [ButtonBorder.RECTANGLE_BORDER]: 'rounded-xl border-2 border-custom-gray-800',
+  [ButtonBorder.RECTANGLE_BORDER]: 'rounded-xl border-1 border-custom-gray-800',
   [ButtonBorder.ROUND]: 'rounded-4xl',
-  [ButtonBorder.ROUND_BORDER]: 'rounded-4xl border-2 border-custom-gray-800',
+  [ButtonBorder.ROUND_BORDER]: 'rounded-4xl border-1 border-custom-gray-800',
 };
 
 const buttonColorStyle = {
-  [BGColor.RED]: 'text-custom-red bg-custom-red-brand',
+  [BGColor.RED]: 'text-custom-red bg-custom-red-brand py-2 md:py-2.5',
   [BGColor.YELLOW]:
-    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-yellow-brand',
+    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-yellow-brand py-2 md:py-2.5',
   [BGColor.WHITE]:
-    'text-sm md:text-base font-semibold  text-custom-gray-800 bg-custom-white ',
+    'text-sm  font-semibold text-nowrap text-custom-gray-800 bg-custom-white px-4 py-2 md:py-2.5 ',
   [BGColor.GRAY]:
-    'text-sm md:text-base font-semibold  text-custom-gray-500 bg-custom-gray-200',
+    'text-sm md:text-base font-semibold  text-custom-gray-500 bg-custom-gray-200 py-2 md:py-2.5',
   [BGColor.DARK_GRAY]:
-    'text-sm md:text-base font-bold text-custom-gray-700 bg-custom-gray-400',
+    'text-sm md:text-base font-bold text-custom-gray-700 bg-custom-gray-400 py-3 md:py-3.5',
   [BGColor.BLACK]:
-    'text-sm md:text-base font-semibold text-custom-white bg-custom-gray-800',
+    'text-sm md:text-base font-semibold text-custom-white bg-custom-gray-800 py-2 md:py-2.5',
 };
 
 const ButtonIconChoice = {
@@ -99,7 +99,7 @@ export default function Button({
   closeIcon = false,
   ...props
 }: ButtonProps) {
-  const baseStyle = 'w-full px-30 py-3 md:py-3.5 justify-center cursor-pointer';
+  const baseStyle = 'w-full  justify-center cursor-pointer';
   const bgColorStyle = buttonColorStyle[bgColor];
   const borderStyle = ButtonBorderStyle[border];
   const iconChoice = icon ? ButtonIconChoice[icon] : null;
@@ -108,10 +108,14 @@ export default function Button({
     return (
       <Link
         href={href}
-        className={`flex gap-2  justify-center items-center ${baseStyle} ${bgColorStyle} ${borderStyle}`}
+        className={`flex gap-2 justify-center items-center px-4 ${baseStyle} ${bgColorStyle} ${borderStyle}`}
       >
         {children}
-        <Image src={iconChoice} alt="button Icon" width={16} />
+        {icon ? (
+          <Image src={iconChoice} alt="button Icon" width={16} height={16} />
+        ) : (
+          ''
+        )}
       </Link>
     );
   }
@@ -119,7 +123,7 @@ export default function Button({
     <>
       {onlyIcon ? (
         <button {...props}>
-          <Image src={iconChoice} alt="feedback icon" width={40} />
+          <Image src={iconChoice} alt="feedback icon" width={40} height={40} />
         </button>
       ) : (
         <button

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -1,0 +1,79 @@
+import timerIcon from '@images/deadLine-icon/small.svg';
+import personIcon from '@images/person-icon/small.svg';
+import Image from 'next/image';
+import selectorIcon from '@images/menu-icon/Meatballs.svg';
+import dayjs from '@/lib/utill';
+import { DocumentType, FieldType } from '@/types';
+import { Chip } from '../chip/chip';
+import Button, { BGColor, ButtonBorder, ButtonImg } from '../button/Button';
+
+export interface CardProps {
+  title: string;
+  DocumentType: DocumentType;
+  FieldType: FieldType;
+  deadLine: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  href: string;
+}
+
+export const Card = ({
+  title,
+  DocumentType,
+  FieldType,
+  deadLine,
+  currentParticipants,
+  maxParticipants,
+  href,
+}: CardProps) => {
+  const maxParticipant = maxParticipants === currentParticipants;
+
+  return (
+    <div className="flex flex-col w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 ">
+      <section className="flex w-full justify-between relative">
+        <div className="flex flex-col gap-4 ">
+          {maxParticipant ? (
+            <div className="flex">
+              <Chip label={DocumentType} />
+            </div>
+          ) : (
+            ''
+          )}
+          <p className="text-xl text-custom-gray-700 font-bold">{title}</p>
+          <div className="flex gap-1.5 ">
+            <Chip label={FieldType} />
+            <Chip label={DocumentType} />
+          </div>
+        </div>
+        <Image
+          src={selectorIcon}
+          alt="selector Icon"
+          className="absolute right-0"
+        />
+      </section>
+
+      <section className="flex w-full justify-between pt-4  border-t border-custom-gray-200">
+        <div className="flex items-center w-full gap-1">
+          <Image src={timerIcon} alt="deadLine Icon" width={16} height={16} />
+          <p className="text-sm font-normal text-custom-gray-600">
+            {dayjs(deadLine).format('YYYY년 M월 D일')} 마감
+          </p>
+          <Image src={personIcon} alt="person Icon" width={16} height={16} />
+          <p className="text-sm font-normal text-custom-gray-600">
+            {currentParticipants}/{maxParticipants}
+          </p>
+        </div>
+        <div className="flex w-40 ">
+          <Button
+            border={ButtonBorder.ROUND_BORDER}
+            bgColor={BGColor.WHITE}
+            icon={ButtonImg.CONTINUE}
+            href={href}
+          >
+            도전 계속하기
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/shared/components/input/search.tsx
+++ b/src/shared/components/input/search.tsx
@@ -38,7 +38,7 @@ const Search: FC<SearchInputProps> = ({ name, placeholder, onSearch }) => {
   };
 
   return (
-    <div className="mb-4 relative">
+    <div className=" relative">
       <input
         type="search"
         name={name}


### PR DESCRIPTION
## 📌 개요

- 챌린지 목록 보기 페이지 UI구현

## ✨ 주요 변경 사항

- 페이지에 들어가는 UI를 구현
- 페이지 네이션 UI 구현 (추후 수정해야 함)
- 챌린지가 있을 때 랑 없을 때 두 가지 경우 구현 완료

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- X

## 🔗 관련 이슈

- 버튼 및 카드 등 공용 컴포넌트는 추후 자연스럽게 반응형이 되게 max-w와 min-w 잡아 리펙토링 할 예정이니 참고 바랍니다!

## 📸 스크린샷

- 챌린지 O
![localhost_3000_main_challenge (1)](https://github.com/user-attachments/assets/6fd10474-b7ed-4a51-ab86-01a20d7914bc)

- 챌린지 X
![localhost_3000_main_challenge](https://github.com/user-attachments/assets/ef4efad0-10cb-483a-a935-e7664eddc2fb)
