### PR TITLE
프론트 상태 관리 및 챌린지 목록, 신규/수정, 페이지 로그인/회원가입 구현완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@tanstack/react-query": "^5.69.0",
         "@tanstack/react-query-devtools": "^5.69.0",
+        "axios": "^1.8.4",
         "dayjs": "^1.11.13",
         "next": "15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
-        "react-hot-toast": "^2.5.2"
+        "react-hot-toast": "^2.5.2",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.6",
@@ -3482,7 +3484,7 @@
       "version": "19.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4577,6 +4579,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4601,6 +4609,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4749,7 +4768,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5068,6 +5086,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -5278,6 +5308,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5322,7 +5361,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5451,7 +5489,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5461,7 +5498,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5506,7 +5542,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5519,7 +5554,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6283,6 +6317,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6316,6 +6370,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -6335,7 +6404,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6409,7 +6477,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6434,7 +6501,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6591,7 +6657,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6680,7 +6745,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6693,7 +6757,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6709,7 +6772,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8181,7 +8243,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8226,6 +8287,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -9086,6 +9168,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -11505,6 +11593,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   "dependencies": {
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",
+    "axios": "^1.8.4",
     "dayjs": "^1.11.13",
     "next": "15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
-    "react-hot-toast": "^2.5.2"
+    "react-hot-toast": "^2.5.2",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.6",

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,18 @@
+import ReactQueryProvider from '@/core/contexts/ReactQueryProvider';
+import ToastProvider from '@/core/contexts/ToastProvider';
+import '@shared/globals.css';
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ReactQueryProvider>
+      <ToastProvider />
+      <section className="flex flex-col justify-center items-center px-4 md:px-28  gap-10 ">
+        {children}
+      </section>
+    </ReactQueryProvider>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,66 +1,31 @@
-import { NextPage } from 'next';
-import mainLogo from '@images/img_logo .svg';
+'use client';
 
-import Image from 'next/image';
-import Button, {
-  BGColor,
-  ButtonBorder,
-} from '@/shared/components/button/Button';
-import Link from 'next/link';
+import AuthForm from '@/shared/components/form/AuthForm';
+import { NextPage } from 'next';
+import { useForm, FormProvider } from 'react-hook-form';
+import { useLogin } from '@/core/hooks/auth/useLogine';
 
 const Login: NextPage = () => {
+  const methods = useForm();
+  const login = useLogin();
+
+  const handleSubmit = async (data: any) => {
+    login.mutate({
+      email: data.email,
+      password: data.password,
+    });
+  };
+
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-28   gap-10 ">
-      <section>
-        <Link
-          href={'/'}
-          className="flex justify-center items-center pt-32 gap-3.5"
-        >
-          <Image src={mainLogo} alt="main logo" />
-        </Link>
-      </section>
-
-      <div className="flex flex-col justify-center w-full md:w-lg gap-6">
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">이메일</p>
-          <input
-            type="email"
-            placeholder="이메일을 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">비밀번호</p>
-          <input
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section>
-          <Button
-            border={ButtonBorder.LITTLE_RECTANGLE}
-            bgColor={BGColor.BLACK}
-          >
-            로그인
-          </Button>
-        </section>
-
-        <section className="flex gap-2 justify-center  ">
-          <p className="text-base font-normal text-custom-gray-600">
-            회원이 아니신가요?
-          </p>
-          <Link
-            href={'/auth/signup'}
-            className="text-base text-custom-gray-800 font-normal underline"
-          >
-            회원가입하기
-          </Link>
-        </section>
-      </div>
-    </div>
+    <>
+      <FormProvider {...methods}>
+        <AuthForm
+          category="login"
+          onSubmit={methods.handleSubmit(handleSubmit)}
+          isPending={login.isPending}
+        />
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,88 +1,33 @@
-import { NextPage } from 'next';
-import mainLogo from '@images/logo-icon/mainLogo.svg';
-import textLogo from '@images/logo-icon/textLogo.svg';
-import Image from 'next/image';
-import Button, {
-  BGColor,
-  ButtonBorder,
-} from '@/shared/components/button/Button';
-import Link from 'next/link';
+'use client';
 
+import { useSignup } from '@/core/hooks/auth/useSignup';
+import AuthForm from '@/shared/components/form/AuthForm';
+import { NextPage } from 'next';
+import { useForm, FormProvider } from 'react-hook-form';
 
 const SignUp: NextPage = () => {
+  const methods = useForm();
+  const sign = useSignup();
+
+  const handleSubmit = async (data: any) => {
+    console.log('data', data);
+    sign.mutate({
+      email: data.email,
+      nickName: data.nickName,
+      password: data.password,
+    });
+  };
+
   return (
-    <div className="flex flex-col justify-center items-center px-4 md:px-28   gap-10 ">
-      <section>
-        <Link
-          href={'/'}
-          className="flex justify-center items-center pt-32 gap-3.5"
-        >
-          <Image src={mainLogo} alt="main logo" width={46} height={54} />
-          <Image src={textLogo} alt="text logo" width={229} height={82} />
-        </Link>
-      </section>
-
-      <div className="flex flex-col justify-center w-full md:w-lg gap-6">
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">이메일</p>
-          <input
-            type="email"
-            placeholder="이메일을 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">닉네임</p>
-          <input
-            type="text"
-            placeholder="이메일을 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">비밀번호</p>
-          <input
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section className="flex flex-col gap-2">
-          <p className="text-sm font-medium text-custom-gray-900">
-            비밀번호 확인
-          </p>
-          <input
-            type="password"
-            placeholder="비밀번호를 한번 더 입력해주세요"
-            className="flex px-7 border border-custom-gray-200 rounded-xl bg-white py-3.5"
-          ></input>
-        </section>
-
-        <section>
-          <Button
-            border={ButtonBorder.LITTLE_RECTANGLE}
-            bgColor={BGColor.BLACK}
-          >
-            회원가입
-          </Button>
-        </section>
-
-        <section className="flex gap-2 justify-center  ">
-          <p className="text-base font-normal text-custom-gray-600">
-            회원이신가요?
-          </p>
-          <Link
-            href={'/auth/login'}
-            className="text-base text-custom-gray-800 font-normal underline"
-          >
-            로그인하기
-          </Link>
-        </section>
-      </div>
-    </div>
+    <>
+      <FormProvider {...methods}>
+        <AuthForm
+          category="signup"
+          onSubmit={methods.handleSubmit(handleSubmit)}
+          isPending={sign.isPending}
+        />
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,30 @@
+'use client';
+
 import '@shared/globals.css';
+
 import ToastProvider from '@/core/contexts/ToastProvider';
 import Layout from '@/shared/components/layout/Layout';
+import { usePathname } from 'next/navigation';
+import ReactQueryProvider from '@/core/contexts/ReactQueryProvider';
+import { AuthProvider } from '@/core/contexts/AuthProvider';
 
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const pathname = usePathname();
+  const isAuthPage = pathname.startsWith('/auth');
+
   return (
     <html lang="kor">
       <body>
         <ToastProvider />
-        {/* <ReactQueryProvider> */}
-        <Layout>{children}</Layout>
-        {/* </ReactQueryProvider> */}
+        <ReactQueryProvider>
+          <AuthProvider>
+            {isAuthPage ? <>{children}</> : <Layout>{children}</Layout>}
+          </AuthProvider>
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/src/app/main/challenge/[id]/edit/page.tsx
+++ b/src/app/main/challenge/[id]/edit/page.tsx
@@ -1,14 +1,59 @@
 'use client';
 
-import ChallengeForm from '@/shared/components/form/ChallengeForm';
+import { useEditChallenge } from '@/core/hooks/challenge/useEditChallenge';
+import { fetchChallengeById } from '@/lib/api/challenge';
+import ChallengeForm, {
+  ChallengeFormData,
+} from '@/shared/components/form/ChallengeForm';
+import { DocumentType, FieldType } from '@/types';
 import { NextPage } from 'next';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
 const Edit: NextPage = () => {
-  const methods = useForm();
+  const methods = useForm<ChallengeFormData>({
+    defaultValues: {
+      title: '',
+      originURL: '',
+      documentType: DocumentType['BLOG'],
+      field: FieldType['NEXTJS'],
+      deadline: new Date(),
+      maxParticipants: 5,
+      description: '',
+    },
+  });
 
-  const handleSubmit = (data: any) => {
-    console.log('수정할 데이터:', data);
+  const params = useParams();
+  const challengeId = params?.id as string;
+
+  const { mutateAsync } = useEditChallenge(challengeId);
+
+  useEffect(() => {
+    const fetchDefault = async () => {
+      if (!challengeId) return;
+      const challenge = await fetchChallengeById(challengeId);
+      methods.reset({
+        ...challenge,
+        deadline: new Date(challenge.deadline).toISOString().split('T')[0],
+      } as unknown as ChallengeFormData);
+    };
+
+    fetchDefault();
+  }, [challengeId]);
+
+  const handleSubmit = async (data: ChallengeFormData) => {
+    try {
+      const parsedData = {
+        ...data,
+        deadline: new Date(data.deadline),
+      };
+      await mutateAsync(parsedData);
+      return true;
+    } catch (err) {
+      console.error('수정 실패:', err);
+      return false;
+    }
   };
 
   return (

--- a/src/app/main/challenge/_components/ChallengeHead.tsx
+++ b/src/app/main/challenge/_components/ChallengeHead.tsx
@@ -13,7 +13,7 @@ export default function ChallengeHead() {
           border={ButtonBorder.ROUND}
           bgColor={BGColor.BLACK}
           icon={ButtonImg.NEWCHALLENGE}
-          href={'/auth/login'}
+          href={'/main/challenge/new'}
         >
           신규 챌린지 신청
         </Button>

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -17,11 +17,12 @@ const ChallengeMain = () => {
   // const [approvalStatus, setApprovalStatus] = useState<string>();
 
   const { data, isPending } = useToastQuery(
-    ['challenges', page, limit],
+    ['challenges', page, limit, keyword],
     () =>
       fetchChallenges({
         page,
         limit: 10,
+        keyword,
       }),
     'challenge-toast',
     {

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -1,75 +1,65 @@
 'use client';
 
-import Button, {
-  BGColor,
-  ButtonBorder,
-} from '@/shared/components/button/Button';
-import { Card, CardProps } from '@/shared/components/card/Card';
+import { Card } from '@/shared/components/card/Card';
 import Search from '@/shared/components/input/search';
-import { DocumentType, FieldType } from '@/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Pagination from './Pagination';
-
-const seedData: CardProps[] = [
-  // {
-  //   title: 'Next.js로 블로그 만들기',
-  //   DocumentType: DocumentType.BLOG,
-  //   FieldType: FieldType.NEXTJS,
-  //   deadLine: '2025-04-15',
-  //   currentParticipants: 3,
-  //   maxParticipants: 5,
-  //   href: '/projects/nextjs-blog',
-  // },
-  // {
-  //   title: '모던 자바스크립트 완전 정복',
-  //   DocumentType: DocumentType.OFFICIAL,
-  //   FieldType: FieldType.MODERNJS,
-  //   deadLine: '2025-04-20',
-  //   currentParticipants: 5,
-  //   maxParticipants: 10,
-  //   href: '/projects/modernjs-master',
-  // },
-  // {
-  //   title: 'REST API 실전 프로젝트',
-  //   DocumentType: DocumentType.BLOG,
-  //   FieldType: FieldType.API,
-  //   deadLine: '2025-05-01',
-  //   currentParticipants: 2,
-  //   maxParticipants: 6,
-  //   href: '/projects/rest-api-practice',
-  // },
-];
+import { Filter } from '@/shared/components/dropdown/Filter';
+import { useToastQuery } from '@/shared/hooks/useToastQuery';
+import { fetchChallenges } from '@/lib/api/challenge';
 
 const ChallengeMain = () => {
-  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [keyword, setKeyword] = useState('');
+  // const [documentType, setDocumentType] = useState<string>();
+  // const [fields, setFields] = useState<string[]>();
+  // const [approvalStatus, setApprovalStatus] = useState<string>();
 
-  const handleSearch = (e: string) => {
-    setSearch(e);
-  };
+  const { data, isPending } = useToastQuery(
+    ['challenges', page, limit],
+    () =>
+      fetchChallenges({
+        page,
+        limit: 10,
+      }),
+    'challenge-toast',
+    {
+      pending: '불러오는 중...',
+      success: '불러오기 완료!',
+      error: '불러오기 실패!',
+    }
+  );
+
+  const challenges = data?.challengesWithIsMax ?? [];
+  const totalPages = Math.ceil((data?.totalCount ?? 1) / limit);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [page]);
 
   return (
     <div className="flex flex-col gap-6 ">
       <section className="flex gap-3">
         <div className="flex items-center">
-          <Button
-            border={ButtonBorder.RECTANGLE_BORDER}
-            bgColor={BGColor.WHITE}
-          >
-            필터 버튼 자리
-          </Button>
+          <Filter />
         </div>
 
         <div className="w-full">
           <Search
             name={'text'}
             placeholder="챌린지 이름을 검색해보세요"
-            onSearch={handleSearch}
+            onSearch={(e) => {
+              setKeyword(e);
+              setPage(1);
+            }}
+            size="w-full"
           />
         </div>
       </section>
 
       <section className="flex flex-col gap-6 w-full">
-        {seedData.length === 0 ? (
+        {challenges.length === 0 ? (
           <div className="flex h-screen justify-center items-center">
             <p className="text-center text-gray-500">
               아직 챌린지가 없어요.
@@ -79,25 +69,29 @@ const ChallengeMain = () => {
           </div>
         ) : (
           <>
-            {seedData.map((data, index) => (
+            {challenges.map((data, index) => (
               <Card
+                category="base"
                 key={index}
                 title={data.title}
-                DocumentType={data.DocumentType}
-                FieldType={data.FieldType}
-                deadLine={data.deadLine}
+                DocumentType={data.documentType}
+                FieldType={data.field}
+                deadLine={data.deadline}
                 currentParticipants={data.currentParticipants}
                 maxParticipants={data.maxParticipants}
-                href={data.href}
               />
             ))}
           </>
         )}
       </section>
 
-      {seedData.length > 0 && (
+      {challenges.length > 0 && totalPages > 1 && (
         <section className="flex justify-center">
-          <Pagination totalPages={20} />
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={(newPage) => setPage(newPage)}
+          />
         </section>
       )}
     </div>

--- a/src/app/main/challenge/_components/Pagination.tsx
+++ b/src/app/main/challenge/_components/Pagination.tsx
@@ -7,13 +7,16 @@ import prevBlack from '@images/arrow-icon/no-stick/black.svg';
 
 type PaginationProps = {
   totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
 };
-
 const blockSize = 5;
 
-const Pagination = ({ totalPages }: PaginationProps) => {
-  const [currentPage, setCurrentPage] = useState(1);
-
+const Pagination = ({
+  totalPages,
+  currentPage,
+  onPageChange,
+}: PaginationProps) => {
   const currentBlock = Math.floor((currentPage - 1) / blockSize);
   const startPage = currentBlock * blockSize + 1;
   const endPage = Math.min(startPage + blockSize - 1, totalPages);
@@ -29,7 +32,7 @@ const Pagination = ({ totalPages }: PaginationProps) => {
   return (
     <div className="flex w-72 md:w-80 gap-3 items-center justify-center mt-4">
       <button
-        onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+        onClick={() => onPageChange(currentPage - 1)}
         disabled={isPrevDisabled}
       >
         <Image
@@ -46,7 +49,7 @@ const Pagination = ({ totalPages }: PaginationProps) => {
         {pageNumbers.map((page) => (
           <button
             key={page}
-            onClick={() => setCurrentPage(page)}
+            onClick={() => onPageChange(page)}
             className={`w-10 h-10 rounded-xl ${
               page === currentPage
                 ? 'bg-custom-gray-800 text-sm text-custom-yellow-brand font-medium'
@@ -59,7 +62,7 @@ const Pagination = ({ totalPages }: PaginationProps) => {
       </div>
 
       <button
-        onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+        onClick={() => onPageChange(currentPage + 1)}
         disabled={isNextDisabled}
       >
         <Image

--- a/src/app/main/challenge/layout.tsx
+++ b/src/app/main/challenge/layout.tsx
@@ -6,8 +6,6 @@ export default function ChallengeLayout({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex gap-4 flex-col px-4 md:px-6 xl:px-[28.875rem] pt-20 pb-28">
-      {children}
-    </section>
+    <section className="flex flex-col pt-7 pb-28 gap-4">{children}</section>
   );
 }

--- a/src/app/main/challenge/new/page.tsx
+++ b/src/app/main/challenge/new/page.tsx
@@ -1,22 +1,34 @@
 'use client';
 
-import ChallengeForm from '@/shared/components/form/ChallengeForm';
+import { useCreateChallenge } from '@/core/hooks/challenge/useCreateChallenge';
+import ChallengeForm, {
+  ChallengeFormData,
+} from '@/shared/components/form/ChallengeForm';
+import { DocumentType, FieldType } from '@/types';
 import { NextPage } from 'next';
 import { useForm, FormProvider } from 'react-hook-form';
 
 const NewChallenge: NextPage = () => {
   const methods = useForm();
+  const { mutateAsync } = useCreateChallenge();
 
-  const handleSubmit = (data: any) => {
-    console.log('신규 데이터:', data);
+  const handleSubmit = async (data: ChallengeFormData) => {
+    const formattedData = {
+      ...data,
+      deadline: new Date(data.deadline),
+      maxParticipants: Number(data.maxParticipants),
+      documentType: data.documentType as DocumentType,
+      field: data.field as FieldType,
+    };
+    return await mutateAsync(formattedData);
   };
 
   return (
-    <div>
+    <>
       <FormProvider {...methods}>
         <ChallengeForm category="create" onSubmit={handleSubmit} />
       </FormProvider>
-    </div>
+    </>
   );
 };
 

--- a/src/app/main/challenge/page.tsx
+++ b/src/app/main/challenge/page.tsx
@@ -2,13 +2,13 @@ import { NextPage } from 'next';
 import ChallengeHead from './_components/ChallengeHead';
 import ChallengeMain from './_components/ChallengeMain';
 
-const ChallengeDetail: NextPage = () => {
+const Challenge: NextPage = () => {
   return (
-    <div className="flex gap-4 flex-col px-4 md:px-6 xl:px-[28.875rem] pt-20 pb-28">
+    <>
       <ChallengeHead />
       <ChallengeMain />
-    </div>
+    </>
   );
 };
 
-export default ChallengeDetail;
+export default Challenge;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,20 @@
 'use client';
 
+import { useAuth } from '@/core/contexts/AuthProvider';
+
 export default function Home() {
+  const { clearAuth } = useAuth();
+
+  const handleLogout = () => {
+    clearAuth();
+    window.location.href = '/';
+  };
   return (
     <>
       <div className="flex w-full h-10 bg-sky-50">메인 홈페이지</div>
-      <div className="flex justify-center w-full"></div>
+      <div className="flex justify-center w-full">
+        <button onClick={handleLogout}>로그아웃</button>
+      </div>
     </>
   );
 }

--- a/src/core/contexts/ToastProvider.tsx
+++ b/src/core/contexts/ToastProvider.tsx
@@ -3,5 +3,14 @@
 import { Toaster } from 'react-hot-toast';
 
 export default function ToastProvider() {
-  return <Toaster position="bottom-right" />;
+  return (
+    <Toaster
+      position="top-center"
+      toastOptions={{
+        duration: 3000,
+      }}
+      containerStyle={{ pointerEvents: 'none' }}
+      reverseOrder={false}
+    />
+  );
 }

--- a/src/core/hooks/auth/useLogine.ts
+++ b/src/core/hooks/auth/useLogine.ts
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/navigation';
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
+import { useAuthStore } from '@/stores/authStore';
+import { loginFn } from '@/lib/api/auth';
+
+export const useLogin = () => {
+  const router = useRouter();
+  const { setAuth } = useAuthStore();
+
+  return useToastMutation(
+    loginFn,
+    {
+      pending: '로그인 중입니다...',
+      success: '로그인 성공!',
+      error: '로그인 실패! 이메일 또는 비밀번호를 확인해주세요.',
+    },
+    {
+      onSuccess: ({ user, accessToken, refreshToken }) => {
+        setAuth(user, accessToken, refreshToken);
+
+        const path = localStorage.getItem('redirectAfterLogin') || '/';
+        localStorage.removeItem('redirectAfterLogin');
+        setTimeout(() => {
+          router.push(path);
+        }, 1500);
+      },
+    },
+    'login-toast'
+  );
+};

--- a/src/core/hooks/auth/useLogout.ts
+++ b/src/core/hooks/auth/useLogout.ts
@@ -1,0 +1,12 @@
+import { useAuthStore } from '@/stores/authStore';
+import toast from 'react-hot-toast';
+
+export const useLogout = () => {
+  const { clearAuth } = useAuthStore();
+
+  return () => {
+    clearAuth();
+    toast.success('로그아웃 되었습니다!');
+    window.location.href = '/';
+  };
+};

--- a/src/core/hooks/auth/useSignup.ts
+++ b/src/core/hooks/auth/useSignup.ts
@@ -1,0 +1,22 @@
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
+import { useRouter } from 'next/navigation';
+import { signupFn } from '@/lib/api/auth';
+
+export const useSignup = () => {
+  const router = useRouter();
+
+  return useToastMutation(
+    signupFn,
+    {
+      pending: '회원가입 중입니다...',
+      success: '회원가입 성공! 로그인 페이지로 이동 중 ~',
+      error: '회원가입 실패!',
+    },
+    {
+      onSuccess: () => {
+        router.push('/auth/login');
+      },
+    },
+    'signup-toast'
+  );
+};

--- a/src/core/hooks/challenge/useCreateChallenge.ts
+++ b/src/core/hooks/challenge/useCreateChallenge.ts
@@ -1,0 +1,24 @@
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
+import { ChallengeFormRequest, createChallenge } from '@/lib/api/challenge';
+import { useRouter } from 'next/navigation';
+
+export const useCreateChallenge = () => {
+  const router = useRouter();
+
+  return useToastMutation<ChallengeFormRequest, unknown, any>(
+    createChallenge,
+    {
+      pending: '챌린지를 생성 중입니다...',
+      success: '챌린지 생성 완료! 챌린지 페이지로 이동 중!',
+      error: '챌린지 생성 실패!',
+    },
+    {
+      onSuccess: () => {
+        setTimeout(() => {
+          router.push('/main/challenge');
+        }, 1500);
+      },
+    },
+    'challenge-toast'
+  );
+};

--- a/src/core/hooks/challenge/useEditChallenge.ts
+++ b/src/core/hooks/challenge/useEditChallenge.ts
@@ -1,0 +1,26 @@
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
+import { ChallengeFormRequest, editChallenge } from '@/lib/api/challenge';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export const useEditChallenge = (id: string) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get('from');
+
+  return useToastMutation<ChallengeFormRequest, unknown, any>(
+    (data) => editChallenge(id, data),
+    {
+      pending: '챌린지를 수정 중입니다...',
+      success: '챌린지 수정 완료! 상세 페이지로 이동 중!',
+      error: '챌린지 수정 실패!',
+    },
+    {
+      onSuccess: () => {
+        setTimeout(() => {
+          router.push(from ?? `/main/challenge/${id}`);
+        }, 1500);
+      },
+    },
+    'challenge-toast'
+  );
+};

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,20 @@
+import {
+  LoginPayload,
+  LoginResponse,
+  SignupPayload,
+} from '@/core/contexts/AuthProvider';
+import instance from './axiosInstance';
+
+export const loginFn = async (
+  payload: LoginPayload
+): Promise<LoginResponse> => {
+  const res = await instance.post<LoginResponse>('/api/auth/login', payload);
+  return res.data;
+};
+
+export const signupFn = async (
+  payload: SignupPayload
+): Promise<LoginResponse> => {
+  const res = await instance.post<LoginResponse>('/api/auth/signup', payload);
+  return res.data;
+};

--- a/src/lib/api/axiosInstance.ts
+++ b/src/lib/api/axiosInstance.ts
@@ -1,0 +1,66 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { useAuthStore } from '@/stores/authStore';
+import { toast } from 'react-hot-toast';
+import { saveRedirectPath } from '../authRedirect';
+
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+
+const instance = axios.create({
+  baseURL,
+  withCredentials: true,
+});
+
+interface CustomRequest extends AxiosRequestConfig {
+  _retry?: boolean;
+}
+
+instance.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().accessToken;
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+instance.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const originalRequest = error.config as CustomRequest;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      const { refreshToken, user, setAuth, clearAuth } =
+        useAuthStore.getState();
+
+      if (!refreshToken || !user) {
+        clearAuth();
+        toast.error('로그인이 필요합니다.');
+        saveRedirectPath();
+        window.location.href = '/auth/login';
+        return Promise.reject(error);
+      }
+
+      try {
+        const res = await axios.post(`${baseURL}/auth/refresh`, {
+          refreshToken,
+        });
+        const { accessToken } = res.data;
+
+        setAuth(user, accessToken, refreshToken);
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        return instance(originalRequest);
+      } catch (refreshError) {
+        clearAuth();
+        toast.error('재로그인이 필요합니다. 다시 로그인해주세요.');
+        saveRedirectPath();
+        window.location.href = '/auth/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default instance;

--- a/src/lib/api/challenge.ts
+++ b/src/lib/api/challenge.ts
@@ -1,0 +1,53 @@
+import instance from '@/lib/api/axiosInstance';
+import { ChallengeFormData } from '@/shared/components/form/ChallengeForm';
+import { Challenge, DocumentType, FieldType } from '@/types';
+
+export interface FetchChallengeParams {
+  page?: number;
+  limit?: number;
+  documentType?: string;
+  fields?: string[];
+  approvalStatus?: string;
+  keyword?: string;
+}
+
+interface FetchChallengeResponse {
+  challengesWithIsMax: Challenge[];
+  totalCount: number;
+}
+
+export interface ChallengeFormRequest {
+  title: string;
+  originURL: string;
+  documentType: DocumentType;
+  field: FieldType;
+  deadline: Date;
+  maxParticipants: number;
+  description: string;
+}
+
+export const fetchChallenges = async (
+  params: FetchChallengeParams
+): Promise<FetchChallengeResponse> => {
+  const res = await instance.get('/api/challenges', { params });
+  return res.data;
+};
+
+export const fetchChallengeById = async (
+  id: string
+): Promise<ChallengeFormData> => {
+  const response = await instance.get(`/api/challenges/${id}`);
+  console.log('response', response);
+  return response.data.challenge;
+};
+
+export const createChallenge = async (data: ChallengeFormRequest) => {
+  console.log('data', data);
+  const res = await instance.post('/api/challenges', data);
+  return res.data;
+};
+
+export const editChallenge = async (id: string, data: ChallengeFormRequest) => {
+  const res = await instance.patch(`/api/challenges/${id}`, data);
+  return res.data;
+};

--- a/src/lib/authRedirect.ts
+++ b/src/lib/authRedirect.ts
@@ -1,0 +1,13 @@
+import { useRouter } from 'next/navigation';
+
+type Router = ReturnType<typeof useRouter>;
+
+export const saveRedirectPath = () => {
+  localStorage.setItem('redirectAfterLogin', window.location.pathname);
+};
+
+export const redirectAfterAuth = (router: Router) => {
+  const path = localStorage.getItem('redirectAfterLogin') || '/';
+  localStorage.removeItem('redirectAfterLogin');
+  router.push(path);
+};

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -24,6 +24,7 @@ export enum ButtonBorder {
   LITTLE_RECTANGLE_BORDER = 'littleRectangleBorder',
   RECTANGLE = 'rectangle',
   RECTANGLE_BORDER = 'rectangleBorder',
+  RECTANGLE_BIG_BORDER = 'rectangleBigBorder',
   ROUND = 'round',
   ROUND_BORDER = 'roundBorder',
 }
@@ -52,6 +53,8 @@ const ButtonBorderStyle = {
     'rounded-lg border-2 border-custom-gray-800 ',
   [ButtonBorder.RECTANGLE]: 'rounded-xl ',
   [ButtonBorder.RECTANGLE_BORDER]: 'rounded-xl border-1 border-custom-gray-800',
+  [ButtonBorder.RECTANGLE_BIG_BORDER]:
+    'rounded-xl border-3 border-custom-gray-800',
   [ButtonBorder.ROUND]: 'rounded-4xl',
   [ButtonBorder.ROUND_BORDER]: 'rounded-4xl border-1 border-custom-gray-800',
 };

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -4,20 +4,36 @@ import Image from 'next/image';
 import selectorIcon from '@images/menu-icon/Meatballs.svg';
 import dayjs from '@/lib/utill';
 import { DocumentType, FieldType } from '@/types';
-import { Chip } from '../chip/chip';
+import { Chip, ChipProps } from '../chip/chip';
 import Button, { BGColor, ButtonBorder, ButtonImg } from '../button/Button';
+import { ChipCardStatus } from '../chip/ChipCardStatus';
 
 export interface CardProps {
+  category: 'base' | 'my';
   title: string;
   DocumentType: DocumentType;
   FieldType: FieldType;
   deadLine: string;
   currentParticipants: number;
   maxParticipants: number;
-  href: string;
+  href?: string;
 }
 
+const fieldTypeLabelMap: Record<FieldType, string> = {
+  NEXTJS: 'Next.js',
+  MODERNJS: 'Modern JS',
+  API: 'API',
+  WEB: 'Web',
+  CAREER: 'Career',
+};
+
+const documentTypeLabelMap: Record<DocumentType, string> = {
+  OFFICIAL: '공식문서',
+  BLOG: '블로그',
+};
+
 export const Card = ({
+  category,
   title,
   DocumentType,
   FieldType,
@@ -27,22 +43,25 @@ export const Card = ({
   href,
 }: CardProps) => {
   const maxParticipant = maxParticipants === currentParticipants;
+  const overDeadLine = dayjs(deadLine).isBefore(dayjs());
 
   return (
     <div className="flex flex-col w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 ">
       <section className="flex w-full justify-between relative">
         <div className="flex flex-col gap-4 ">
-          {maxParticipant ? (
+          {maxParticipant || overDeadLine ? (
             <div className="flex">
-              <Chip label={DocumentType} />
+              <ChipCardStatus status={maxParticipant ? 'full' : 'done'} />
             </div>
           ) : (
             ''
           )}
           <p className="text-xl text-custom-gray-700 font-bold">{title}</p>
           <div className="flex gap-1.5 ">
-            <Chip label={FieldType} />
-            <Chip label={DocumentType} />
+            <Chip label={fieldTypeLabelMap[FieldType] as ChipProps['label']} />
+            <Chip
+              label={documentTypeLabelMap[DocumentType] as ChipProps['label']}
+            />
           </div>
         </div>
         <Image
@@ -63,16 +82,21 @@ export const Card = ({
             {currentParticipants}/{maxParticipants}
           </p>
         </div>
-        <div className="flex w-40 ">
-          <Button
-            border={ButtonBorder.ROUND_BORDER}
-            bgColor={BGColor.WHITE}
-            icon={ButtonImg.CONTINUE}
-            href={href}
-          >
-            도전 계속하기
-          </Button>
-        </div>
+
+        {category === 'my' ? (
+          <div className="flex w-40 ">
+            <Button
+              border={ButtonBorder.ROUND_BORDER}
+              bgColor={BGColor.WHITE}
+              icon={ButtonImg.CONTINUE}
+              href={href}
+            >
+              도전 계속하기
+            </Button>
+          </div>
+        ) : (
+          ''
+        )}
       </section>
     </div>
   );

--- a/src/shared/components/chip/chip.tsx
+++ b/src/shared/components/chip/chip.tsx
@@ -1,4 +1,4 @@
-interface ChipProps {
+export interface ChipProps {
   label:
     | 'Next.js'
     | 'Modern JS'

--- a/src/shared/components/container/Container.tsx
+++ b/src/shared/components/container/Container.tsx
@@ -36,10 +36,10 @@ export const Container = ({
         </p>
       </section>
 
-      <section className="flex  md:flex-col md:items-center gap-1">
+      <section className="flex  md:flex-col md:items-center gap-3">
         <div className="flex w-40 md:w-56 xl:w-60 ">
           <Button
-            border={ButtonBorder.RECTANGLE_BORDER}
+            border={ButtonBorder.RECTANGLE_BIG_BORDER}
             bgColor={BGColor.YELLOW}
             href={originUrl}
           >

--- a/src/shared/components/form/AuthForm.tsx
+++ b/src/shared/components/form/AuthForm.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import mainLogo from '@images/img_logo .svg';
+import Image from 'next/image';
+import Button, {
+  BGColor,
+  ButtonBorder,
+} from '@/shared/components/button/Button';
+import Email from '../input/email';
+import Password from '../input/password';
+import Text from '../input/text';
+import Link from 'next/link';
+import { useFormContext } from 'react-hook-form';
+
+interface AuthFormProps {
+  category: 'login' | 'signup';
+  onSubmit: (data: any) => Promise<void>;
+  isPending?: boolean;
+}
+
+const AuthForm = ({ category, onSubmit, isPending }: AuthFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useFormContext();
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <section>
+        <Link
+          href={'/'}
+          className="flex justify-center items-center pt-32 gap-3.5"
+        >
+          <Image src={mainLogo} alt="main logo" />
+        </Link>
+      </section>
+
+      <div className="flex flex-col justify-center w-full md:w-lg gap-6">
+        <section className="flex flex-col gap-2">
+          <p className="M-14-0 text-custom-gray-900 font-(family-name:--pretendard)">
+            이메일
+          </p>
+          <Email
+            name="email"
+            placeholder="이메일을 입력해주세요"
+            register={register}
+            errors={errors}
+            size="w-full h-12"
+          />
+        </section>
+
+        {category === 'signup' ? (
+          <>
+            <section className="flex flex-col gap-2">
+              <p className="M-14-0 text-custom-gray-900">닉네임</p>
+              <Text
+                name="nickName"
+                placeholder="닉네임을 입력해주세요"
+                register={register}
+                size="w-full h-12"
+              />
+            </section>
+          </>
+        ) : (
+          ''
+        )}
+
+        <section className="flex flex-col gap-2">
+          <p className="M-14-0 text-custom-gray-900">비밀번호</p>
+          <Password
+            name="password"
+            placeholder="비밀번호를 입력해주세요"
+            register={register}
+            errors={errors}
+            size="w-full h-12"
+          />
+        </section>
+
+        {category === 'signup' && (
+          <section className="flex flex-col gap-2">
+            <p className="M-14-0 text-custom-gray-900">비밀번호</p>
+            <Password
+              name="passwordConfirm"
+              placeholder="비밀번호를 한번 더 입력해주세요"
+              register={register}
+              errors={errors}
+              isConfirm
+              compareValue={watch('password')}
+              size="w-full h-12"
+            />
+          </section>
+        )}
+
+        <section>
+          <Button
+            type="submit"
+            border={ButtonBorder.LITTLE_RECTANGLE}
+            bgColor={isPending ? BGColor.GRAY : BGColor.BLACK}
+          >
+            {category === 'login' ? '로그인' : '회원가입'}
+          </Button>
+        </section>
+
+        <section className="flex gap-2 justify-center  ">
+          <p className="R-16-0 text-custom-gray-600">
+            {category === 'login' ? '회원이 아니신가요?' : '이미 회원이신가요?'}
+          </p>
+          <Link
+            href={category === 'login' ? '/auth/signup' : '/auth/login'}
+            className="R-16-0 text-custom-gray-800  underline"
+          >
+            {category === 'login' ? '회원가입하기' : '로그인하기'}
+          </Link>
+        </section>
+      </div>
+    </form>
+  );
+};
+
+export default AuthForm;

--- a/src/shared/components/form/ChallengeForm.tsx
+++ b/src/shared/components/form/ChallengeForm.tsx
@@ -1,79 +1,138 @@
 'use client';
 
 import Text from '../input/text';
-
 import Date from '../input/date';
 import Button, { BGColor, ButtonBorder } from '../button/Button';
+import { DocumentType, FieldType } from '@/types';
+import { DropDown } from '../dropdown/DropDown';
+import { useFormContext } from 'react-hook-form';
 
 interface ChallengeFormProps {
   category: 'edit' | 'create';
-  // defaultValues?: {
-  //   title: string;
-  //   originUrl: string;
-  //   FieldType: FieldType;
-  //   documentType: DocumentType;
-  //   deadline: string;
-  //   maxParticipants: string;
-  //   content: string;
-  // };
-  onSubmit: (data: any) => void;
+  defaultValues?: ChallengeFormData;
+  onSubmit: (data: any) => Promise<unknown>;
+  isPending?: boolean;
 }
 
-const ChallengeForm = ({
-  category,
-  // defaultValues,
-  onSubmit,
-}: ChallengeFormProps) => {
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const data = Object.fromEntries(formData.entries());
+export interface ChallengeFormData {
+  title: string;
+  originURL: string;
+  documentType: DocumentType;
+  field: FieldType;
+  deadline: Date;
+  maxParticipants: number;
+  description: string;
+}
 
-    onSubmit(data);
-  };
+export const DocumentTypeLabel: Record<DocumentType, string> = {
+  [DocumentType.BLOG]: '블로그',
+  [DocumentType.OFFICIAL]: '공식문서',
+};
+
+export const FieldTypeLabel: Record<FieldType, string> = {
+  [FieldType.NEXTJS]: 'Next.js',
+  [FieldType.MODERNJS]: 'Modern JS',
+  [FieldType.API]: 'API',
+  [FieldType.WEB]: 'WEB',
+  [FieldType.CAREER]: 'Career',
+};
+
+const ChallengeForm = ({ category, onSubmit }: ChallengeFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+
+  const documentType = watch('documentType');
+  const field = watch('field');
+
+  const documentTypeOptions = Object.values(DocumentType).map((value) => ({
+    value,
+    name: DocumentTypeLabel[value],
+  }));
+
+  const fieldTypeOptions = Object.values(FieldType).map((value) => ({
+    value,
+    name: FieldTypeLabel[value],
+  }));
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
       <p className="text-lg md:text-xl font-bold">
         {category === 'edit' ? '챌린지 수정' : '신규 챌린지 신청'}
       </p>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">제목</p>
-        <Text name="title" placeholder="제목을 입력해주세요" />
+        <Text
+          name="title"
+          placeholder="제목을 입력해주세요"
+          register={register}
+          size="w-full h-12"
+        />
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">원문 링크</p>
-        <Text name="originUrl" placeholder="원문 링크를 입력해주세요"></Text>
+        <Text
+          name="originURL"
+          placeholder="원문 링크를 입력해주세요"
+          register={register}
+          size="w-full h-12"
+        ></Text>
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">분야</p>
-        <Text name="fieldType" placeholder="카테고리"></Text>
+        <DropDown
+          options={fieldTypeOptions}
+          value={field}
+          placeholder="분야 선택"
+          handleChange={(v) => setValue('field', v)}
+        />
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">문서 타입</p>
-        <Text name="documentType" placeholder="YY/MM/DD"></Text>
+        <DropDown
+          options={documentTypeOptions}
+          value={documentType}
+          placeholder="문서 타입 선택"
+          handleChange={(v) => setValue('documentType', v)}
+        />
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">마감일</p>
-        <Date name="deadline" placeholder="YY/MM/DD"></Date>
+        <Date
+          name="deadline"
+          placeholder="YY/MM/DD"
+          register={register}
+          size="w-full h-12 px-3"
+        ></Date>
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">최대 인원</p>
         <Text
           name="maxParticipants"
-          placeholder="원문 링크를 입력해주세요"
+          placeholder="최대 인원 수를 입력해주세요"
+          register={register}
+          size="w-full h-12"
         ></Text>
       </section>
 
       <section className="flex flex-col gap-2">
         <p className="text-sm text-custom-gray-900 font-medium ">내용</p>
-        <Text name="content" placeholder="내용을 입력해주세요"></Text>
+        <Text
+          name="description"
+          placeholder="내용을 입력해주세요"
+          register={register}
+          size="w-full h-40"
+        ></Text>
       </section>
 
       <Button

--- a/src/shared/hooks/useToastMutation.ts
+++ b/src/shared/hooks/useToastMutation.ts
@@ -19,28 +19,40 @@ export function useToastMutation<
 >(
   mutationFn: (variables: TVariables) => Promise<TData>,
   toastMessages?: ToastMessages,
-  options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  options?: UseMutationOptions<TData, TError, TVariables, TContext>,
+  toastId?: string
 ): UseMutationResult<TData, TError, TVariables, TContext> {
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn,
     ...options,
     onMutate: async (variables) => {
-      toast.dismiss();
-      if (toastMessages?.pending) toast.loading(toastMessages.pending);
+      if (toastId) toast.dismiss(toastId);
+      if (toastMessages?.pending)
+        toast.loading(toastMessages.pending, {
+          id: toastId,
+          duration: 3000,
+        });
       return options?.onMutate?.(variables);
     },
     onSuccess: (data, variables, context) => {
-      toast.dismiss();
-      if (toastMessages?.success) toast.success(toastMessages.success);
+      if (toastId) toast.dismiss(toastId);
+      if (toastMessages?.success)
+        toast.success(toastMessages.success, {
+          id: toastId,
+          duration: 3000,
+        });
       options?.onSuccess?.(data, variables, context);
     },
     onError: (error, variables, context) => {
-      toast.dismiss();
-      if (toastMessages?.error) toast.error(toastMessages.error);
+      if (toastId) toast.dismiss(toastId);
+      if (toastMessages?.error)
+        toast.error(toastMessages.error, {
+          id: toastId,
+          duration: 3000,
+        });
       options?.onError?.(error, variables, context);
     },
     onSettled: (data, error, variables, context) => {
-      toast.dismiss();
       options?.onSettled?.(data, error, variables, context);
     },
   });

--- a/src/shared/hooks/useToastQuery.ts
+++ b/src/shared/hooks/useToastQuery.ts
@@ -39,6 +39,7 @@ export function useToastQuery<
 >(
   queryKey: TQueryKey,
   queryFn: () => Promise<TQueryFnData>,
+  toastId?: string,
   toastMessages?: ToastMessages,
   options: ToastQueryOptions<TQueryFnData, TError, TData, TQueryKey> = {}
 ): UseQueryResult<TData, TError> {
@@ -54,12 +55,12 @@ export function useToastQuery<
     queryFn,
     ...restOptions,
     onSuccess: (data: TData) => {
-      toast.dismiss();
+      if (toastId) toast.dismiss(toastId);
       if (toastMessages?.success) toast.success(toastMessages.success);
       userOnSuccess?.(data);
     },
     onError: (error: TError, variables: TQueryKey, context: unknown) => {
-      toast.dismiss();
+      if (toastId) toast.dismiss(toastId);
       if (toastMessages?.error) toast.error(toastMessages.error);
       userOnError?.(error, variables, context);
     },
@@ -69,7 +70,7 @@ export function useToastQuery<
       variables: TQueryKey,
       context: unknown
     ) => {
-      toast.dismiss();
+      if (toastId) toast.dismiss(toastId);
       userOnSettled?.(data, error, variables, context);
     },
   } as UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>;

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,35 @@
+import { User } from '@/types';
+import axios from 'axios';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type SetUser = Omit<User, 'password'>;
+
+export interface AuthState {
+  user: SetUser | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  setAuth: (user: SetUser, accessToken: string, refreshToken: string) => void;
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create(
+  persist<AuthState>(
+    (set) => ({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      setAuth: (user, accessToken, refreshToken) =>
+        set({ user, accessToken, refreshToken }),
+      clearAuth: () => {
+        set({ user: null, accessToken: null, refreshToken: null });
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        delete axios.defaults.headers.common['Authorization'];
+      },
+    }),
+    {
+      name: 'auth-storage',
+    }
+  )
+);

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -28,7 +28,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const chip: Story = {
+export const button: Story = {
   args: {
     border: ButtonBorder.RECTANGLE,
     bgColor: BGColor.RED,

--- a/src/stories/Card.stories.ts
+++ b/src/stories/Card.stories.ts
@@ -25,7 +25,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const chip: Story = {
+export const card: Story = {
   args: {
     title: 'Next.js - App Router: Routing Fundamentals',
     DocumentType: DocumentType.OFFICIAL,

--- a/src/stories/Container.stories.ts
+++ b/src/stories/Container.stories.ts
@@ -14,7 +14,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const chip: Story = {
+export const container: Story = {
   args: {
     originUrl: '/',
     deadLine: '2025-03-28',

--- a/src/stories/Tab.stories.ts
+++ b/src/stories/Tab.stories.ts
@@ -24,7 +24,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const chip: Story = {
+export const tab: Story = {
   args: {
     position: TextPosition.MIDDLE,
     isActive: TabActive.ON,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface Challenge {
   title: string;
   originUrl: string;
   documentType: DocumentType;
-  deadline: Date;
+  deadline: string;
   maxParticipants: number;
   currentParticipants: number;
   description: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,7 +967,7 @@
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz"
   integrity sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==
 
-"@types/react@^19", "@types/react@^19.0.0", "@types/react@>=16":
+"@types/react@^19", "@types/react@^19.0.0", "@types/react@>=16", "@types/react@>=18.0.0":
   version "19.0.12"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz"
   integrity sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==
@@ -1421,6 +1421,11 @@ async-function@^1.0.0:
   resolved "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -1432,6 +1437,15 @@ axe-core@^4.10.0:
   version "4.10.3"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz"
   integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
+
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -1649,6 +1663,13 @@ colorette@^2.0.20:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^13.1.0:
   version "13.1.0"
   resolved "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz"
@@ -1776,6 +1797,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
@@ -2385,6 +2411,11 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz"
@@ -2399,6 +2430,16 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -3242,6 +3283,18 @@ micromatch@^4.0.4, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz"
@@ -3659,6 +3712,11 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.15.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz"
@@ -3739,7 +3797,7 @@ react-is@^17.0.1:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-"react@^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react@^18 || ^19", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.0.0, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16:
+"react@^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react@^18 || ^19", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.0.0, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16, react@>=18.0.0:
   version "19.0.0"
   resolved "https://registry.npmjs.org/react/-/react-19.0.0.tgz"
   integrity sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==
@@ -4858,3 +4916,8 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+zustand@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz"
+  integrity sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==


### PR DESCRIPTION
## 📌 개요

- 프론트 상태 관리 구현
- 챌린지 목록 페이지 로직 연결 및 구현
- 챌린지 신규/ 수정 페이지, 로직 연결 및 구현
- 로그인/회원가입 로직 연결 및 구현 완료

## ✨ 주요 변경 사항

- 프론트 상태 관리 구현 (공유 사항에 노션 첨부, 확인바랍니다.)
- 페이지 마다 로직 연결 완료 

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 상태관리
https://www.notion.so/1c936713bdaf8072ae4ee6c10acb6884

- 토스트
https://www.notion.so/1bb36713bdaf8069b84fd0fbdcc11d6b?v=1bb36713bdaf803ba03e000ce5c24428&p=1c236713bdaf809fa512c7f07112668f&pm=s

- 욕심을 너무 채워서 여러가지 수정이 합쳐졌습니다. 다음부터는 분할해서 PR 올리도록 주의하겠습니다

- 고려사항
1. 서버액션 사용
    → 서버액션 사용으로 데이터 미리 받아옴 
    → 클라이언트 컴포넌트(useQuery, useMutation 사용) 
    → 최상단은 서버 컴포넌트(page.tsx) 

## 🔗 관련 이슈

- #42 
- #9 
- #33 
- #10 
- #7 
- #8 

## 📸 스크린샷

-첼린지 목록 페이지 
![localhost_3000_main_challenge](https://github.com/user-attachments/assets/488322f4-2dfb-4bdd-a6b4-4eb2040f10f5)
![localhost_3000_main_challenge (1)](https://github.com/user-attachments/assets/16667bc8-d9b0-4087-ad6a-51d4ad1f385f)

-첼린지 목록 페이지 리엑트 쿼리 데브 툴 데이터 확인
![image](https://github.com/user-attachments/assets/e73bcd16-d6ce-426c-890f-8ba8ba1b62a7)

-첼린지 생성 페이지
![image](https://github.com/user-attachments/assets/69f9be84-89fb-4d97-aa02-556fe34b3e16)

-첼린지 수정 페이지(위에서 생성한 데이터 id만 주소의 기입)
![localhost_3000_main_challenge_51fcf6ff-3173-4d21-aa99-d2119c22cddb_edit](https://github.com/user-attachments/assets/37010de1-c87c-434c-a8e1-7ff15bd8990a)

-로그인 (네트워크 리스폰 데이터)
![image](https://github.com/user-attachments/assets/cef71559-c489-4fb6-bb04-e9aa419ef3f2)

-회원가입(네트워크 리스폰 데이터)
![image](https://github.com/user-attachments/assets/26c73565-ecae-4352-acde-4e4510dbf977)
