### PR TITLE
feat: 임시저장에 토스트 적용, 수정 페이지 작업 [수정 api 아직 미연동]

### DIFF
--- a/src/api/TransLationApi.ts
+++ b/src/api/TransLationApi.ts
@@ -33,11 +33,33 @@ export const getTranLationList = async (challengeId: string) => {
     challengeId,
   }: {
     title: string;
-    content: string;
+    content: string | null;
     challengeId: string;
   }) => {
     const response = await docThro.post(
       `/challenges/${challengeId}/translations`,
+      {
+        title,
+        content,
+      }
+    );
+    return response;
+  };
+
+  // 번역물을 수정하는 API
+  export const modifyTranslation = async ({
+    title,
+    content,
+    challengeId,
+    translationId,
+  }: {
+    title: string;
+    content: string | null;
+    challengeId: string;
+    translationId: string;
+  }) => {
+    const response = await docThro.patch(
+      `/challenges/${challengeId}/translations/${translationId}`,
       {
         title,
         content,
@@ -53,7 +75,7 @@ export const getTranLationList = async (challengeId: string) => {
       challengeId,
     }: {
       title: string;
-      content: string;
+      content: string | null;
       challengeId: string;
     }) => {
       const response = await docThro.post(`/challenges/${challengeId}/drafts`, {
@@ -62,6 +84,8 @@ export const getTranLationList = async (challengeId: string) => {
       });
       return response;
     };
+
+    
   
     // 임시 저장된 번역물을 가져오는 API
     export const getDraftTranslation = async (challengeId : string) => {

--- a/src/app/main/translation-work/[id]/page.tsx
+++ b/src/app/main/translation-work/[id]/page.tsx
@@ -4,31 +4,157 @@ import { NextPage } from 'next';
 import Image from 'next/image';
 import Logo from '@/shared/Img/logo.svg';
 import Close from '@/shared/Img/close-icon/close.svg';
-import Button, {
-  BGColor,
-  ButtonBorder,
-} from '@/shared/components/button/Button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ConfirmCancel from '@/shared/components/modal/confirmCancel';
 import Navigate from '@/shared/components/modal/navigate';
 import Editor from '../_components/Editor';
 import Confirm from '@/shared/components/modal/confirm';
-import { useRouter } from 'next/navigation';
+import { notFound, useParams, useRouter } from 'next/navigation';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { ErrorMessage, ErrorResponse } from '@/types';
+import {
+  createDraftTranslation,
+  createTranslation,
+  getDraftTranslation,
+  getTranLation,
+  modifyTranslation,
+} from '@/api/TransLationApi';
+import Button, { ButtonCategory } from '@/shared/components/button/Button';
+import { useUnloadWarning } from '@/shared/hooks/useUnloadWarning';
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
 
-const TranslationWork: NextPage = () => {
+const TranslationWorkModify: NextPage = () => {
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | null>(null);
   const [isDrafted, setIsDrafted] = useState(false);
   const [isDraftModal, setIsDraftModal] = useState(false);
   const [isDraftQuestionModal, setIsDraftQuestionModal] = useState(false);
   const [isForgiveModal, setIsForgiveModal] = useState(false);
   const [isSuccessModal, setIsSuccessModal] = useState(false);
+  const [isErrorModal, setIsErrorModal] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [challengeId, setChallengeId] = useState<string>('');
+  const [isLoaded, setIsLoaded] = useState(false);
+
   const router = useRouter();
+  const params = useParams();
+  const translationId = params.id as string;
+
+  const { data: TranslationData } = useQuery({
+    queryKey: ['Translation', challengeId, translationId],
+    queryFn: ({ queryKey }) => {
+      const [, challengeId] = queryKey;
+      return getTranLation(challengeId, translationId);
+    },
+    enabled: !!challengeId, // ✅ 이거 꼭 필요!
+  });
+
+  console.log('TranslationData: ', TranslationData);
+
+  // 로컬 스토리지에서 저장되어 있는 Challenge Id를 불러옵니다.
+  useEffect(() => {
+    const cid = localStorage.getItem('challengeId') as string;
+    if (!cid) router.replace('/not-found');
+    else setChallengeId(cid);
+  }, []);
+
+  useEffect(() => {
+    if (
+      TranslationData?.title !== undefined &&
+      TranslationData?.content !== undefined
+    ) {
+      setTitle(TranslationData.title);
+      setContent(TranslationData.content);
+      setIsLoaded(true);
+    }
+  }, [TranslationData]);
+
+  useUnloadWarning(content !== '');
+
+  const { data: draftData } = useQuery({
+    queryKey: ['draft', challengeId],
+    queryFn: ({ queryKey }) => {
+      const [, challengeId] = queryKey;
+      return getDraftTranslation(challengeId as string);
+    },
+  });
+
+  useEffect(() => {
+    if (draftData?.status === 200) {
+      setIsDrafted(true);
+    }
+    console.log(draftData, 'draftData');
+  }, [draftData]);
+
+  // 번역물 생성 Mutation
+  const modifyTranslationMutation = useMutation({
+    mutationFn: modifyTranslation,
+    onSuccess: (data) => {
+      setIsSuccessModal(true);
+      console.log('성공', data);
+    },
+    onError: (error) => {
+      const axiosError = error as AxiosError<ErrorResponse>;
+      const data = axiosError.response?.data;
+      let message = '알 수 없는 에러가 발생했어요.';
+
+      if (data && typeof data.message === 'string') {
+        // message가 그냥 string일 경우
+        message = data.message;
+      } else if (
+        data &&
+        typeof data.message === 'object' &&
+        data.message !== null
+      ) {
+        const messageObj = data.message as ErrorMessage;
+
+        // formErrors가 있는 경우
+        if (
+          Array.isArray(messageObj.formErrors) &&
+          messageObj.formErrors.length > 0
+        ) {
+          message = messageObj.formErrors.join('\n');
+        }
+
+        // fieldErrors가 있는 경우
+        else if (messageObj.fieldErrors) {
+          const fieldMessages = Object.entries(messageObj.fieldErrors)
+            .map(([field, errors]) => `${errors.join('\n')}`)
+            .join('\n');
+          message = fieldMessages;
+        }
+      }
+      setErrorMessage(message);
+      setIsErrorModal(true);
+    },
+  });
+
+  // 임시 저장 번역물 생성 Mutation
+  const createDraftMutation = useToastMutation(
+    createDraftTranslation,
+    {
+      pending: '임시저장 중입니다...',
+      success: '임시저장 성공!',
+      error: '임시저장 실패 😢',
+    },
+    {
+      onSuccess: () => {
+        console.log('성공 후 추가 작업');
+      },
+    },
+    'save-translation' // <- toastId (중복 방지용 고유 id)
+  );
+
   return (
     <div className="w-screen h-screen flex flex-col items-center p-2">
       <div className="max-w-[1000px] w-full h-full">
         <div className="mt-6 flex justify-between h-[80px] items-center">
-          <div>
+          <div
+            onClick={() => {
+              setIsForgiveModal(true);
+            }}
+          >
             <Image
               className={'cursor-pointer'}
               width={120}
@@ -37,36 +163,40 @@ const TranslationWork: NextPage = () => {
               alt="logo"
             />
           </div>
-          <div className="flex gap-2 h-[40px]">
-            <div className="w-[81px]">
+          <div className="flex gap-2">
+            <div className="md:w-[81px] w-[36px]">
               <Button
-                border={ButtonBorder.RECTANGLE}
-                bgColor={BGColor.RED}
-                closeIcon={true}
+                category={ButtonCategory.DROP}
+                size={'py-2 flex'}
                 onClick={() => {
                   setIsForgiveModal(true);
                 }}
               >
-                포기
+                <p className="hidden md:flex">포기</p>
               </Button>
             </div>
-            <div className="w-[90px]">
+            <div className="w-[90px] flex items-center">
               <Button
-                border={ButtonBorder.RECTANGLE_BORDER}
-                bgColor={BGColor.WHITE}
+                category={ButtonCategory.NO}
+                size={'py-2 flex'}
                 onClick={() => {
-                  setIsDraftModal(true);
+                  createDraftMutation.mutate({ title, content, challengeId });
                 }}
               >
                 임시저장
               </Button>
             </div>
-            <div className="w-[90px] h-[40px]">
+            <div className="w-[95px] flex items-center">
               <Button
-                border={ButtonBorder.RECTANGLE}
-                bgColor={BGColor.BLACK}
+                category={ButtonCategory.YES}
+                size={'py-2 flex'}
                 onClick={() => {
-                  setIsSuccessModal(true);
+                  modifyTranslationMutation.mutate({
+                    title,
+                    content,
+                    challengeId,
+                    translationId,
+                  });
                 }}
               >
                 수정하기
@@ -78,15 +208,21 @@ const TranslationWork: NextPage = () => {
           <div className="mb-5">
             <input
               className="text-[36px] w-full"
-              placeholder='제목을 입력하세요.'
+              placeholder="제목을 입력하세요."
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
           </div>
           <hr />
-          <div className="mt-5">
-            <Editor setContent={setContent} content={content} draftedValue="" />
-          </div>
+          {isLoaded && (
+            <div className="mt-5">
+              <Editor
+                setContent={setContent}
+                content={content}
+                draftedValue=""
+              />
+            </div>
+          )}
         </div>
         <Confirm
           isOpen={isDraftModal}
@@ -97,6 +233,15 @@ const TranslationWork: NextPage = () => {
           }}
         >
           임시저장 되었습니다!
+        </Confirm>
+        <Confirm
+          isOpen={isErrorModal}
+          onClose={() => setIsErrorModal(false)}
+          onConfirm={() => {
+            setIsErrorModal(false);
+          }}
+        >
+          {errorMessage}
         </Confirm>
         <ConfirmCancel
           isOpen={isDraftQuestionModal}
@@ -114,7 +259,7 @@ const TranslationWork: NextPage = () => {
           onClose={() => setIsForgiveModal(false)}
           onConfirm={() => {
             setIsForgiveModal(false);
-            router.push('/main/challenge')
+            router.push(`/main/translation/${translationId}`);
           }}
           onCancel={() => setIsForgiveModal(false)}
         >
@@ -123,13 +268,13 @@ const TranslationWork: NextPage = () => {
         <Navigate
           isOpen={isSuccessModal}
           onClose={() => {}}
-          navigateUrl="/main/challenge"
+          navigateUrl={`/main/translation/${translationId}`}
           text="작업물 보기"
         >
           수정되었습니다!
         </Navigate>
         {isDrafted && (
-          <div className="border border-[#262626] rounded-[8px] fixed left-1/2 top-[90%] transform -translate-x-1/2 z-30 max-w-[750px] w-full flex justify-between items-center px-5">
+          <div className="border border-[#262626] rounded-[8px] fixed left-1/2 top-[90%] transform -translate-x-1/2 z-30 max-w-[750px] w-[95%] flex justify-between items-center px-5">
             <div className="flex gap-5 items-center">
               <div
                 onClick={() => {
@@ -148,12 +293,14 @@ const TranslationWork: NextPage = () => {
                 임시 저장된 작업물이 있어요. 저장된 작업을 불러오시겠어요??
               </div>
             </div>
-            <div className="w-[90px]">
+            <div className="w-[90px] my-1">
               <Button
-                border={ButtonBorder.RECTANGLE}
-                bgColor={BGColor.BLACK}
+                category={ButtonCategory.YES}
+                size={'py-1 flex'}
                 onClick={() => {
-                  setIsDraftQuestionModal(true);
+                  setTitle(draftData?.data.data.title);
+                  setContent(draftData?.data.data.content);
+                  setIsDrafted(false);
                 }}
               >
                 불러오기
@@ -165,4 +312,4 @@ const TranslationWork: NextPage = () => {
     </div>
   );
 };
-export default TranslationWork;
+export default TranslationWorkModify;

--- a/src/app/main/translation-work/[id]/page.tsx
+++ b/src/app/main/translation-work/[id]/page.tsx
@@ -70,7 +70,7 @@ const TranslationWorkModify: NextPage = () => {
     }
   }, [TranslationData]);
 
-  useUnloadWarning(content !== '');
+  useUnloadWarning(content !== '' && !isSuccessModal);
 
   const { data: draftData } = useQuery({
     queryKey: ['draft', challengeId],

--- a/src/app/main/translation-work/_components/Editor.tsx
+++ b/src/app/main/translation-work/_components/Editor.tsx
@@ -1,35 +1,42 @@
-"use client";
-import dynamic from "next/dynamic";
-import { Dispatch, SetStateAction, useState } from "react";
-import "react-quill-new/dist/quill.snow.css"; // 기본 테마
+'use client';
+import dynamic from 'next/dynamic';
+import { Dispatch, SetStateAction, useState } from 'react';
+import 'react-quill-new/dist/quill.snow.css'; // 기본 테마
 
 // ✅ 동적 import로 서버에서 실행되지 않도록 설정
-const ReactQuill = dynamic(() => import("react-quill-new"), { ssr: false });
+const ReactQuill = dynamic(() => import('react-quill-new'), { ssr: false });
 
 const modules = {
   toolbar: [
-    ["bold", "italic", "underline", "strike"], // 굵기, 기울임, 밑줄, 취소선
-    [{ list: "ordered" }, { list: "bullet" }], // 리스트 (번호, 불렛)
-    ["blockquote", "code-block"], // 블록 인용, 코드 블록
-    [{ indent: "-1" }, { indent: "+1" }], // 들여쓰기
-    [{ size: ["small", false, "large", "huge"] }], // 폰트 크기
+    ['bold', 'italic', 'underline', 'strike'], // 굵기, 기울임, 밑줄, 취소선
+    [{ list: 'ordered' }, { list: 'bullet' }], // 리스트 (번호, 불렛)
+    ['blockquote', 'code-block'], // 블록 인용, 코드 블록
+    [{ indent: '-1' }, { indent: '+1' }], // 들여쓰기
+    [{ size: ['small', false, 'large', 'huge'] }], // 폰트 크기
     [{ color: [] }, { background: [] }], // 글씨 색상, 배경색 ✅ 추가
     [{ align: [] }], // 정렬 기능 ✅ 추가
-    ["clean"], // 포맷 초기화
+    ['clean'], // 포맷 초기화
   ],
 };
 
 interface EditorProps {
-  draftedValue?:string;
-  content:string;
-  setContent:Dispatch<SetStateAction<string>>;
+  draftedValue?: string;
+  content: string | null;
+  setContent: Dispatch<SetStateAction<string | null>>;
 }
 
-const Editor: React.FC<EditorProps> = ({content, setContent}) => {
+const Editor: React.FC<EditorProps> = ({ content, setContent}) => {
+  
 
   return (
     <div className="w-full p-4">
-      <ReactQuill theme="snow" value={content} onChange={setContent} modules={modules} placeholder="내용을 입력하세요." />
+      <ReactQuill
+        theme="snow"
+        value={content ?? ''}
+        onChange={setContent}
+        modules={modules}
+        placeholder="내용을 입력하세요."
+      />
     </div>
   );
 };

--- a/src/app/main/translation-work/page.tsx
+++ b/src/app/main/translation-work/page.tsx
@@ -20,10 +20,11 @@ import {
 } from '@/api/TransLationApi';
 import Button, { ButtonCategory } from '@/shared/components/button/Button';
 import { useUnloadWarning } from '@/shared/hooks/useUnloadWarning';
+import { useToastMutation } from '@/shared/hooks/useToastMutation';
 
 const TranslationWork: NextPage = () => {
   const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState<string | null>(null);
   const [isDrafted, setIsDrafted] = useState(false);
   const [isDraftModal, setIsDraftModal] = useState(false);
   const [isDraftQuestionModal, setIsDraftQuestionModal] = useState(false);
@@ -33,6 +34,7 @@ const TranslationWork: NextPage = () => {
   const [errorMessage, setErrorMessage] = useState<string>('');
   const router = useRouter();
   const [challengeId, setChallengeId] = useState<string>('');
+  const [translationId, setTranslationId] = useState(''); 
 
   // 로컬 스토리지에서 저장되어 있는 Challenge Id를 불러옵니다.
   useEffect(() => {
@@ -41,7 +43,7 @@ const TranslationWork: NextPage = () => {
     else setChallengeId(cid);
   }, []);
 
-  useUnloadWarning(content !== '');
+  useUnloadWarning(content !== '' && !isSuccessModal);
 
   const { data: draftData } = useQuery({
     queryKey: ['draft', challengeId],
@@ -62,8 +64,8 @@ const TranslationWork: NextPage = () => {
   const createTranslationMutation = useMutation({
     mutationFn: createTranslation,
     onSuccess: (data) => {
+      setTranslationId(data.data.id);
       setIsSuccessModal(true);
-      console.log('성공', data);
     },
     onError: (error) => {
       const axiosError = error as AxiosError<ErrorResponse>;
@@ -107,17 +109,20 @@ const TranslationWork: NextPage = () => {
   });
 
   // 임시 저장 번역물 생성 Mutation
-  const createDraftMutation = useMutation({
-    mutationFn: createDraftTranslation,
-    onSuccess: (data) => {
-      setIsDraftModal(true);
-      console.log('성공', data);
+  const createDraftMutation = useToastMutation(
+    createDraftTranslation,
+    {
+      pending: '임시저장 중입니다...',
+      success: '임시저장 성공!',
+      error: '임시저장 실패 😢',
     },
-    onError: (error) => {
-      setErrorMessage('임시저장 중 에러 발생!');
-      setIsErrorModal(true);
+    {
+      onSuccess: () => {
+        console.log('성공 후 추가 작업');
+      },
     },
-  });
+    'save-translation' // <- toastId (중복 방지용 고유 id)
+  );
 
   return (
     <div className="w-screen h-screen flex flex-col items-center p-2">
@@ -225,7 +230,7 @@ const TranslationWork: NextPage = () => {
           onClose={() => setIsForgiveModal(false)}
           onConfirm={() => {
             setIsForgiveModal(false);
-            router.push('/main/challenge');
+            router.push(`/main/challenge/${challengeId}`);
           }}
           onCancel={() => setIsForgiveModal(false)}
         >
@@ -234,7 +239,7 @@ const TranslationWork: NextPage = () => {
         <Navigate
           isOpen={isSuccessModal}
           onClose={() => {}}
-          navigateUrl={`/main/challenge/${challengeId}`}
+          navigateUrl={`/main/translation/${translationId}`}
           text="작업물 보기"
         >
           제출되었습니다!


### PR DESCRIPTION
## 📌 개요

- 임시저장에 토스트 적용, 수정 페이지 작업 [수정 api 아직 미연동]

## ✨ 주요 변경 사항

- 수정 페이지 접속했을 때 자료 불러오기
- 라우팅 더 자연스럽게 연결

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- #67 

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/ab719861-4a75-45ef-b4a9-e21c9344ded8)

1. 수정 페이지 들어오면 이전에 있던 번역물 가져와서 바로 에디터 및 제목에 적용

![image](https://github.com/user-attachments/assets/9598899b-db0c-4352-a681-28cf97ce4a8d)

2. 임시저장 성공 시


