### PR TITLE
[Fix]어드민 챌린지 신청 관리 페이지 상태 chip 누락 해결 & chip 컴포넌트 수정

### DIFF
--- a/src/app/admin/challenges/components/ChallengeTable.tsx
+++ b/src/app/admin/challenges/components/ChallengeTable.tsx
@@ -1,12 +1,27 @@
 import { Chip } from '@/shared/components/chip/chip';
 
-const ChallengeTable = ({ data }) => {
+interface ChallengeTableProps {
+  data: {
+    no: number;
+    type: string;
+    category: string;
+    title: string;
+    people: number;
+    createdAt: string;
+    deadline: string;
+    status: string; // ApprovalStatusLabels 값 중
+    id: string;
+  }[];
+}
+
+const ChallengeTable = ({ data }: ChallengeTableProps) => {
   return (
-    <div className="overflow-x-auto relative shadow-md ">
+    <div className="overflow-x-auto relative shadow-md">
+      {/* 테이블 헤더 */}
       <div className="flex justify-between gap-3 md:gap-0 whitespace-nowrap text-[15px] bg-gray-800 text-white py-2 px-3 rounded-lg">
         <span className="flex-1">No.</span>
         <span className="flex-[1.2]">분야</span>
-        <span className="flex-[1.3] ">카테고리</span>
+        <span className="flex-[1.3]">카테고리</span>
         <span className="flex-5">챌린지 제목</span>
         <span className="flex-[1.2]">모집 인원</span>
         <span className="flex-[1.3]">신청일</span>
@@ -14,23 +29,25 @@ const ChallengeTable = ({ data }) => {
         <span className="flex-[1.5]">상태</span>
       </div>
 
+      {/* 테이블 본문 */}
       <table className="w-full">
         <tbody>
           {data.map((row, index) => (
             <tr
               key={index}
-              className="flex justify-between whitespace-nowrap bg-white border-b border-gray-400  text-sm px-3 py-4 text-gray-400"
+              className="flex justify-between whitespace-nowrap bg-white border-b border-gray-400 text-sm px-3 py-4 text-gray-400"
             >
               <td className="flex-1">{row.no}</td>
               <td className="flex-[1.2]">{row.type}</td>
-              <td className="flex-[1.3] ">{row.category}</td>
+              <td className="flex-[1.3]">{row.category}</td>
               <td className="flex-5 overflow-hidden text-overflow-ellipsis whitespace-nowrap mr-3">
                 {row.title}
               </td>
               <td className="flex-[1.2] pl-2">{row.people}</td>
               <td className="flex-[1.3]">{row.createdAt}</td>
               <td className="flex-[1.3]">{row.deadline}</td>
-              <td className="flex-[1.5] ">
+              <td className="flex-[1.5]">
+                {/* Chip 컴포넌트에서 이미 매핑 */}
                 <Chip label={row.status} />
               </td>
             </tr>

--- a/src/app/admin/challenges/page.tsx
+++ b/src/app/admin/challenges/page.tsx
@@ -8,15 +8,20 @@ import ChallengeTable from './components/ChallengeTable';
 import { Sort } from '@/shared/components/dropdown/Sort';
 import { useQuery } from '@tanstack/react-query';
 import { ChallengeOrderBy, fetchChallengesByAdmin } from '@/lib/api/admin';
-
-export interface TabProps {
-  defaultTabIndex: number;
-  onClick: (index: number) => void;
-  tabs: string[];
+import { ApprovalStatus, ApprovalStatusLabels } from '@/types';
+interface ChallengeApiResponse {
+  id: string;
+  idx: number;
+  title: string;
+  documentType: string;
+  field: string;
+  maxParticipants: number;
+  createdAt: string;
+  deadline: string;
+  approvalStatus: string;
 }
 
 const AdminChallenge: NextPage = () => {
-  const [, setKeyword] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [sortValue, setSortValue] = useState('option1');
   const [page, setPage] = useState(1);
@@ -24,13 +29,13 @@ const AdminChallenge: NextPage = () => {
 
   const getParamsFromSortValue = (value: string) => {
     const mapping: Record<string, any> = {
-      option1: { approvalStatus: 'PENDING' }, // 승인 대기
-      option2: { approvalStatus: 'APPROVED' }, // 신청 승인
-      option3: { approvalStatus: 'REJECTED' }, // 신청 거절
-      option4: { order: ChallengeOrderBy.CREATED_FIRST }, // 신청 시간 빠른순
-      option5: { order: ChallengeOrderBy.CREATED_LAST }, // 신청 시간 느린순
-      option6: { order: ChallengeOrderBy.DEADLINE_FIRST }, // 마감 기한 빠른순
-      option7: { order: ChallengeOrderBy.DEADLINE_LAST }, // 마감 기한 느린순
+      option1: { approvalStatus: 'PENDING' },
+      option2: { approvalStatus: 'APPROVED' },
+      option3: { approvalStatus: 'REJECTED' },
+      option4: { order: ChallengeOrderBy.CREATED_FIRST },
+      option5: { order: ChallengeOrderBy.CREATED_LAST },
+      option6: { order: ChallengeOrderBy.DEADLINE_FIRST },
+      option7: { order: ChallengeOrderBy.DEADLINE_LAST },
     };
     return mapping[value] || {};
   };
@@ -41,33 +46,36 @@ const AdminChallenge: NextPage = () => {
     keyword: searchTerm,
     ...getParamsFromSortValue(sortValue),
   };
-  console.log('queryParams:', queryParams);
-  // API 호출
+
   const { data, isLoading, error } = useQuery<{
-    challenges: any[];
+    challenges: ChallengeApiResponse[];
     totalCount: number;
   }>({
     queryKey: ['adminChallenges', queryParams],
     queryFn: () => fetchChallengesByAdmin(queryParams),
-    staleTime: 5000, //5초동안 캐시데이터 사용 -> 수정 가능
+    staleTime: 5000,
   });
 
-  //TODO: 검색 전체 데이터에서 가능하게 하는게 좋지 않을까? 현재는 정렬된 데이터에서만 가능
-  const handleSearch = (e: string) => {
-    setKeyword(e);
-    setSearchTerm(e);
-    setPage(1); // 검색 시 첫 페이지로 이동
+  const handleSearch = (term: string) => {
+    setSearchTerm(term);
+    setPage(1);
   };
 
   const handleSortChange = (value: string) => {
     setSortValue(value);
     setPage(1);
-    console.log('Selected:', value);
   };
 
-  //페이지네이션 핸들러
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
+  };
+
+  // 상태값 매핑
+  const getStatusLabel = (status: string): string => {
+    if (Object.values(ApprovalStatus).includes(status as ApprovalStatus)) {
+      return ApprovalStatusLabels[status as ApprovalStatus];
+    }
+    return '승인 대기';
   };
 
   const transformedData =
@@ -87,13 +95,8 @@ const AdminChallenge: NextPage = () => {
         month: '2-digit',
         day: '2-digit',
       }),
-      status:
-        challenge.approvalStatus === 'APPROVED'
-          ? '신청 승인'
-          : challenge.approvalStatus === 'REJECTED'
-            ? '신청 거절'
-            : '승인 대기',
-      id: challenge.id, // 상세페이지 이동시 사용
+      status: getStatusLabel(challenge.approvalStatus),
+      id: challenge.id,
     })) || [];
 
   const options = [
@@ -109,22 +112,22 @@ const AdminChallenge: NextPage = () => {
   return (
     <>
       <div className="flex justify-between items-center mt-8">
-        <p className="text-xl text-custom-gray-800 font-semibold ">
+        <p className="text-xl text-custom-gray-800 font-semibold">
           챌린지 신청 관리
         </p>
       </div>
 
-      <div className="flex flex-col gap-6 ">
+      <div className="flex flex-col gap-6">
         <section className="flex gap-3">
           <div className="w-full">
             <Search
-              name={'text'}
+              name="text"
               placeholder="챌린지 이름을 검색해보세요"
               onSearch={handleSearch}
               size="w-full h-[40px]"
             />
           </div>
-          <div className="whitespace-nowrap text-gray-500 ">
+          <div className="whitespace-nowrap text-gray-500">
             <Sort
               options={options}
               placeholder="승인 대기"
@@ -136,27 +139,17 @@ const AdminChallenge: NextPage = () => {
           </div>
         </section>
 
-        {/* TODO: 로딩 처리 */}
-        {isLoading && (
+        {isLoading ? (
           <div className="flex justify-center py-10">
             <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-gray-900"></div>
           </div>
-        )}
-
-        {/* TODO: 에러 처리 or 토큰 만료되었을때 화면  */}
-        {error && (
+        ) : error ? (
           <div className="text-center text-red-500 py-6">
             데이터를 불러오는 중 오류가 발생했습니다.
           </div>
-        )}
-
-        {/* 챌린지 있는 경우 */}
-        {!isLoading && !error && transformedData.length > 0 && (
+        ) : transformedData.length > 0 ? (
           <ChallengeTable data={transformedData} />
-        )}
-
-        {/* 챌린지 없는 경우 */}
-        {!isLoading && !error && transformedData.length === 0 && (
+        ) : (
           <section className="flex flex-col gap-6 w-full">
             <div className="flex h-100 justify-center items-center">
               <p className="text-center text-gray-500">
@@ -168,11 +161,11 @@ const AdminChallenge: NextPage = () => {
           </section>
         )}
 
-        {/* 페이지네이션 */}
-        {!isLoading && !error && data && data.totalCount > 0 && (
+        {/* 페이지네이션 - 데이터가 있을 때만 */}
+        {!isLoading && !error && (data?.totalCount ?? 0) > 0 && (
           <section className="flex justify-center mb-40">
             <Pagination
-              totalPages={Math.ceil(data.totalCount / limit)}
+              totalPages={Math.ceil((data?.totalCount ?? 0) / limit)}
               currentPage={page}
               onPageChange={handlePageChange}
             />

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -77,5 +77,6 @@ export const fetchChallengesByAdmin = async (
   }
 
   const data = await response.json();
+  console.log('API 응답 데이터:', data);
   return data;
 };

--- a/src/shared/components/chip/chip.tsx
+++ b/src/shared/components/chip/chip.tsx
@@ -1,17 +1,16 @@
-import { DocumentType, FieldType } from '@/types';
+import {
+  DocumentType,
+  FieldType,
+  ApprovalStatusLabels,
+  ApprovalStatus,
+} from '@/types';
+
+type ApprovalStatusLabelType = (typeof ApprovalStatusLabels)[ApprovalStatus];
 
 interface ChipProps {
-  label:
-    | string
-    | DocumentType
-    | FieldType
-    | '승인 대기'
-    | '신청 거절'
-    | '신청 승인'
-    | '챌린지 삭제';
+  label: string | DocumentType | FieldType | ApprovalStatusLabelType;
   className?: string;
 }
-
 export const Chip: React.FC<ChipProps> = ({ label, className }) => {
   const chipTypeStyle = 'B-14-0 w-fit px-3 py-[3px] rounded-lg';
   const chipCategoryStyle =
@@ -25,10 +24,10 @@ export const Chip: React.FC<ChipProps> = ({ label, className }) => {
     Career: `${chipTypeStyle} bg-[#7EB2EE] text-custom-gray-600 `,
     공식문서: chipCategoryStyle,
     블로그: chipCategoryStyle,
-    '승인 대기': `${chipStatusStyle} bg-[#FFFDE7] text-[#F2BC00]`,
-    '신청 거절': `${chipStatusStyle} bg-[#FFF0F0] text-[#E54946]`,
-    '신청 승인': `${chipStatusStyle} bg-[#DFF0FF] text-[#4095DE]`,
-    '챌린지 삭제': `${chipStatusStyle} bg-custom-gray-200 text-custom-gray-500`,
+    [ApprovalStatusLabels.PENDING]: `${chipStatusStyle} bg-[#FFFDE7] text-[#F2BC00]`,
+    [ApprovalStatusLabels.REJECTED]: `${chipStatusStyle} bg-[#FFF0F0] text-[#E54946]`,
+    [ApprovalStatusLabels.APPROVED]: `${chipStatusStyle} bg-[#DFF0FF] text-[#4095DE]`,
+    [ApprovalStatusLabels.DELETED]: `${chipStatusStyle} bg-custom-gray-200 text-custom-gray-500`,
   };
 
   const chipStyle =

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,13 @@ export enum ApprovalStatus {
   REJECTED = 'REJECTED',
   DELETED = 'DELETED',
 }
-
+/** 승인 상태 한글 라벨 매핑 */
+export const ApprovalStatusLabels: Record<ApprovalStatus, string> = {
+  [ApprovalStatus.PENDING]: '승인 대기',
+  [ApprovalStatus.APPROVED]: '신청 승인',
+  [ApprovalStatus.REJECTED]: '신청 거절',
+  [ApprovalStatus.DELETED]: '챌린지 삭제',
+};
 /** 유저 타입 */
 export interface User {
   id: string;


### PR DESCRIPTION
## 📌 개요

- 어드민 챌린지 신청관리 페이지 (/admin/challenges) 목록에서 ApprovalStatus가 DELETED 인 챌린지에 '챌린지 삭제' 상태 chip 적용이 되지 않는 문제 해결

## ✨ 주요 변경 사항 및 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 제가 페이지에서 status 처리할때 DELETED(챌린지 삭제) 값에 대한 처리를 따로 해주지 않아서 삭제된 챌린지도 default인 PENDING(승인 대기) chip으로 표시되고 있었습니다. 
- 수정하려다보니 ApprovalStatus에 대한 한글 값이 Chip 컴포넌트와 페이지에서 각각 중복되며 하드 코딩하고 있다는 걸 알게되서 리팩토링하였습니다. 관련사항 노션에 정리해두었습니다.
  -  https://www.notion.so/ApprovalStatus-Chip-1ce36713bdaf807eb1a5d6e68cc337a1?pvs=4
- ChallengeApiResponse interface 추가하여 any 였던 부분 수정
- ChallengeTable 컴포넌트에 interface추가 등

## 🔗 관련 이슈

- #77


