### PR TITLE
[Feat]쿠키 & 로그아웃 + 페이지네이션, chip 디자인 수정

### DIFF
--- a/src/api/auth/AuthApi.ts
+++ b/src/api/auth/AuthApi.ts
@@ -31,3 +31,10 @@ export const signupFn = async (
   const res = await docThro.post<LoginResponse>('/auth/signup', payload);
   return res.data;
 };
+
+export const logoutFn = async (): Promise<void> => {
+  //로그아웃 함수 추가 ( 통일성 위해서 axios 사용했습니다.)
+  await docThro.post('/auth/logout', null, {
+    withCredentials: true, // HttpOnly 쿠키 포함
+  });
+};

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -4,7 +4,6 @@ import toast from 'react-hot-toast';
 import { loginFn, signupFn, logoutFn } from './AuthApi';
 import { useAuthStore } from './AuthStore';
 import { PATH } from '@/constants';
-import { docThro } from '../url';
 
 export const useLogin = () => {
   const { setAuth } = useAuthStore();
@@ -16,12 +15,8 @@ export const useLogin = () => {
       success: '로그인 성공!',
     },
     {
-      onSuccess: ({ user, accessToken }) => {
+      onSuccess: ({ user }) => {
         setAuth(user);
-        //  accessToken 저장
-        localStorage.setItem('accessToken', accessToken);
-        docThro.defaults.headers.common['Authorization'] =
-          `Bearer ${accessToken}`;
         if (user.role === 'ADMIN') {
           window.location.href = PATH.admin;
         } else {

--- a/src/api/url.ts
+++ b/src/api/url.ts
@@ -10,6 +10,7 @@ export const docThro = axios.create({
   headers: {
     'X-Requested-With': 'XMLHttpRequest',
   },
+  withCredentials: true,
 });
 
 docThro.interceptors.request.use(

--- a/src/app/main/challenge/_components/Pagination.tsx
+++ b/src/app/main/challenge/_components/Pagination.tsx
@@ -33,6 +33,7 @@ const Pagination = ({
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={isPrevDisabled}
+        className={`${isPrevDisabled ? 'cursor-default' : 'cursor-pointer hover:-translate-y-0.5'}`}
       >
         <Image
           key={`${isPrevDisabled}-prev`}
@@ -49,11 +50,12 @@ const Pagination = ({
           <button
             key={page}
             onClick={() => onPageChange(page)}
-            className={`w-10 h-10 rounded-xl ${
-              page === currentPage
-                ? 'bg-custom-gray-800 text-sm text-custom-yellow-brand font-medium'
-                : 'bg-white text-sm text-custom-gray-400 font-medium'
-            }`}
+            className={`w-10 h-10 rounded-xl cursor-pointer transition-all duration-200
+              ${
+                page === currentPage
+                  ? 'bg-custom-gray-800 text-custom-yellow-brand'
+                  : 'bg-white text-custom-gray-400 hover:text-custom-gray-800 hover:font-semibold'
+              }`}
           >
             {page}
           </button>
@@ -63,6 +65,7 @@ const Pagination = ({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={isNextDisabled}
+        className={`${isNextDisabled ? 'cursor-default' : 'cursor-pointer hover:-translate-y-0.5'}`}
       >
         <Image
           key={`${isNextDisabled}-prev`}

--- a/src/shared/components/chip/chip.tsx
+++ b/src/shared/components/chip/chip.tsx
@@ -27,7 +27,7 @@ export const Chip: React.FC<ChipProps> = ({ label, className }) => {
     [ApprovalStatusLabels.PENDING]: `${chipStatusStyle} bg-[#FFFDE7] text-[#F2BC00]`,
     [ApprovalStatusLabels.REJECTED]: `${chipStatusStyle} bg-[#FFF0F0] text-[#E54946]`,
     [ApprovalStatusLabels.APPROVED]: `${chipStatusStyle} bg-[#DFF0FF] text-[#4095DE]`,
-    [ApprovalStatusLabels.DELETED]: `${chipStatusStyle} bg-custom-gray-200 text-custom-gray-500`,
+    [ApprovalStatusLabels.DELETED]: `${chipStatusStyle} whitespace-nowrap bg-custom-gray-200 text-custom-gray-500`,
   };
 
   const chipStyle =


### PR DESCRIPTION
## 📌 개요

- 로그아웃시 쿠키에 저장된 리프레시 토큰 삭제를 위해 백엔드 API 추가하여 연결

## ✨ 주요 변경 사항

- 기존에 만들어 놓으신 api 들과 통일성을 위해 axios로 작업했습니다.
- 로그아웃시 로컬스토리지에 엑세스토큰만 제거를 하던 것을 백엔드 auth/logout 경로 추가 후 쿠키에 저장된 리프레시토큰도 삭제하도록 수정했습니다. 
- 어드민 챌린지 신청관리 페이지에 들어가는 pagination 파일에 페이지네이션 버튼에 cursor-pointer , hover 효과 적용하였습니다.
- chip 컴포넌트 화면크기 줄어들때 줄바꿈 되는 부분 해결 위해 옵션 추가했습니다.


## 🔗 관련 이슈

- #83 

