### PR TITLE
fix: FetchChallengeParams 수정, MyChallengeMain 페이지 api 연결 부분 수정

### DIFF
--- a/src/api/challenge/ChallengeApi.ts
+++ b/src/api/challenge/ChallengeApi.ts
@@ -11,6 +11,7 @@ export interface FetchChallengeParams {
   keyword?: string;
   status?: string;
   isExpired?: boolean;
+  orderBy?: string;
 }
 
 interface FetchChallengeResponse {

--- a/src/app/main/my-challenge/components/MyChallengeMain.tsx
+++ b/src/app/main/my-challenge/components/MyChallengeMain.tsx
@@ -11,6 +11,7 @@ import dayjs from 'dayjs';
 import { Challenge } from '@/types';
 import {
   fetchChallengeByParticipating,
+  fetchChallengeByUser,
   fetchChallenges,
 } from '@/api/challenge/ChallengeApi';
 import { Sort } from '@/shared/components/dropdown/Sort';
@@ -32,16 +33,20 @@ const MyChallengeMain = () => {
   const [page, setPage] = useState(1);
   const [limit] = useState(10);
   const [keyword, setKeyword] = useState('');
+  const [orderBy, setOrderBy] = useState('');
+  const [approvalStatus, setApprovalStatus] = useState('');
   const [activeTab, setActiveTab] = useState<TabKey>('participating');
 
   const { data, isPending } = useToastQuery(
     ['my-challenges', page, limit, keyword, activeTab],
     () => {
       if (activeTab === 'applied') {
-        return fetchChallenges({
+        return fetchChallengeByUser({
           page,
           limit,
           keyword,
+          orderBy,
+          approvalStatus,
         });
       }
       return fetchChallengeByParticipating({


### PR DESCRIPTION
## 📌 개요

- fetchChallengeByUser api 연결 함수를 해당 api(백엔드)에 맞게 연결하였습니다.

## ✨ 주요 변경 사항

- 파라미터 들어가야 할 값들은 추가해 놓았습니다. (정렬, 상태 등)

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- #86 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
