### PR TITLE
[Fix] accessToken 누락으로 인한 알림 요청 인증 실패 해결

### DIFF
--- a/src/api/notification/notification.api.ts
+++ b/src/api/notification/notification.api.ts
@@ -16,12 +16,13 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 export async function fetchNotifications(
   userId?: string
 ): Promise<Notification[]> {
-  const url = userId
-    ? `${BASE_URL}/notifications?userId=${userId}` // userId 있으면 쿼리로 붙임
-    : `${BASE_URL}/notifications`; // 없으면 기본 경로 사용
+  const accessToken = localStorage.getItem('accessToken');
+  const url = `${BASE_URL}/notifications?userId=${userId}`;
 
   const res = await fetch(url, {
-    cache: 'no-store',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
     credentials: 'include',
   });
 
@@ -30,8 +31,13 @@ export async function fetchNotifications(
 }
 
 export const deleteNotification = async (id: number) => {
+  const accessToken = localStorage.getItem('accessToken');
+
   const res = await fetch(`${BASE_URL}/notifications/${id}`, {
     method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
     credentials: 'include',
   });
 

--- a/src/api/notification/notification.api.ts
+++ b/src/api/notification/notification.api.ts
@@ -17,7 +17,10 @@ export async function fetchNotifications(
   userId?: string
 ): Promise<Notification[]> {
   const accessToken = localStorage.getItem('accessToken');
-  const url = `${BASE_URL}/notifications?userId=${userId}`;
+
+  const url = userId
+    ? `${BASE_URL}/notifications?userId=${userId}`
+    : `${BASE_URL}/notifications`;
 
   const res = await fetch(url, {
     headers: {

--- a/src/shared/components/dropdown/ProfileDropdown.tsx
+++ b/src/shared/components/dropdown/ProfileDropdown.tsx
@@ -70,7 +70,7 @@ const ProfileDropdown = () => {
 
             <button
               onClick={logout}
-              className="text-sm text-gray-600 hover:text-black"
+              className="text-sm text-gray-600 hover:text-black cursor-pointer"
             >
               로그아웃
             </button>


### PR DESCRIPTION
## 📌 개요

- 알림 기능이 동작 안해서 확인해보니 accessToken 저장 로직 누락으로 인한 알림 요청 인증 실패 해결

## ✨ 주요 변경 사항

- fetch 요청에 accessToken 헤더 추가하여 인증 실패 해결했습니다.
- 프로필 드롭다운에 로그아웃 버튼에 pointer-cursor 적용했습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 알림 테스트해보시려면 다른 브라우저(ex. 크롬, whale)로 각각 다른 유저 아이디로 접속해서 번역물 생성이나, 피드백 작성 등 해보시면 확인하실 수 있습니다.

## 🔗 관련 이슈

- <!-- 관련된 이슈 번호(#000) 혹은 이슈에 대한 설명을 적어주세요 -->

