### PR TITLE
로그인, 회원가입 폼 데이터 유지 수정

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ export function middleware(request: NextRequest) {
   const token = request.cookies.get('accessToken')?.value;
   const isAdminPage = pathname.startsWith('/admin');
   const isPublic = publicPaths.includes(pathname);
-  console.log('🔥 middleware 실행:', pathname);
+  console.log('🔥 middleware 실행: ', pathname, 'token: ', token);
   if (isPublic) {
     return NextResponse.next();
   }
@@ -49,5 +49,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/auth/:path*', '/main/:path*', '/admin/:path*', '/admin'],
+  matcher: ['/((?!_next|favicon.ico|images|icons|.*\\.svg).*)'],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,12 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
     remotePatterns: [
       {
-        protocol: "https",
-        hostname: "**",
+        protocol: 'https',
+        hostname: '**',
       },
     ],
   },

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import { loginFn, signupFn, logoutFn } from './AuthApi';
 import { useAuthStore } from './AuthStore';
 import { PATH } from '@/constants';
+import { flushSync } from 'react-dom';
 
 export const useLogin = () => {
   const { setAuth } = useAuthStore();
@@ -17,7 +18,9 @@ export const useLogin = () => {
     },
     {
       onSuccess: ({ user }) => {
-        setAuth(user);
+        flushSync(() => {
+          setAuth(user);
+        });
         if (user.role === 'ADMIN') {
           router.replace(PATH.admin);
         } else {
@@ -42,7 +45,7 @@ export const useLogout = () => {
       toast.success('로그아웃 되었습니다!');
       setTimeout(() => {
         router.replace('/auth/login');
-      }, 300);
+      }, 0);
     } catch (err) {
       console.error('❌ 로그아웃 요청 실패:', err);
     }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -3,13 +3,21 @@
 import { useLogin } from '@/api/auth/AuthHook';
 import AuthForm, { AuthFormData } from '@/shared/components/form/AuthForm';
 import { NextPage } from 'next';
+import { useState } from 'react';
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 type LoginFormData = Required<Pick<AuthFormData, 'email' | 'password'>>;
 const Login: NextPage = () => {
-  const methods = useForm<LoginFormData>();
+  const [formValues, setFormValues] = useState<LoginFormData>({
+    email: '',
+    password: '',
+  });
+
+  const methods = useForm<LoginFormData>({ defaultValues: formValues });
   const { mutate, isPending } = useLogin();
 
   const handleSubmit: SubmitHandler<LoginFormData> = async (data) => {
+    setFormValues(data);
+    methods.reset(data);
     mutate({
       email: data.email,
       password: data.password,

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -3,15 +3,26 @@
 import { useSignup } from '@/api/auth/AuthHook';
 import AuthForm, { AuthFormData } from '@/shared/components/form/AuthForm';
 import { NextPage } from 'next';
+import { useState } from 'react';
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 type SignUpFormData = Required<
-  Pick<AuthFormData, 'email' | 'password' | 'nickName'>
+  Pick<AuthFormData, 'email' | 'password' | 'passwordConfirm' | 'nickName'>
 >;
 const SignUp: NextPage = () => {
-  const methods = useForm<SignUpFormData>();
+  const [formValues, setFormValues] = useState<SignUpFormData>({
+    email: '',
+    password: '',
+    passwordConfirm: '',
+    nickName: '',
+  });
+  const methods = useForm<SignUpFormData>({
+    defaultValues: formValues,
+  });
   const { mutate, isPending } = useSignup();
 
   const handleSubmit: SubmitHandler<SignUpFormData> = async (data) => {
+    setFormValues(data);
+    methods.reset(data);
     mutate({
       email: data.email,
       nickName: data.nickName,

--- a/src/shared/components/form/AuthForm.tsx
+++ b/src/shared/components/form/AuthForm.tsx
@@ -12,7 +12,7 @@ import { useFormContext, SubmitHandler } from 'react-hook-form';
 export interface AuthFormData {
   email: string;
   password: string;
-  passwordConfirm?: string;
+  passwordConfirm: string;
   nickName: string;
 }
 

--- a/src/shared/hooks/useToastMutation.ts
+++ b/src/shared/hooks/useToastMutation.ts
@@ -3,7 +3,6 @@ import {
   UseMutationOptions,
   UseMutationResult,
 } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
 import toast from 'react-hot-toast';
 
@@ -50,9 +49,8 @@ export function useToastMutation<
 
       let serverErrorMessage = '문제가 발생했습니다. 다시 시도해주세요.';
 
-      if (isAxiosError(error)) {
-        serverErrorMessage =
-          error.response?.data?.message ?? serverErrorMessage;
+      if (error instanceof Error) {
+        serverErrorMessage = error.message;
       }
 
       toast.error(serverErrorMessage, {

--- a/src/shared/hooks/useToastQuery.ts
+++ b/src/shared/hooks/useToastQuery.ts
@@ -4,7 +4,6 @@ import {
   UseQueryResult,
   QueryKey,
 } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import toast from 'react-hot-toast';
 
 interface ToastMessages {
@@ -67,9 +66,8 @@ export function useToastQuery<
         if (toastId) toast.dismiss(toastId);
         let serverErrorMessage = '데이터를 불러오는 중 오류 발생';
 
-        if (isAxiosError(error)) {
-          serverErrorMessage =
-            error.response?.data?.message ?? serverErrorMessage;
+        if (error instanceof Error) {
+          serverErrorMessage = error.message;
         }
 
         toast.error(serverErrorMessage);


### PR DESCRIPTION
## 📌 개요

- 로그인, 회원가입 폼 데이터 유지 수정

## ✨ 주요 변경 사항

- 디폴트를 넣어서 변경된 값까지 유지되게 설정했습니다.
- 
## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 현재 API 보낼 때 Respone.state 값으로 확인하여 
  비밀번호가 틀릴 시 강제 새로고침이 됩니다.

## 🔗 관련 이슈

- 

## 📸 스크린샷

-
