### PR TITLE
[Fix] 로그인 인증 실패시 에러 처리 버그 해결 + UI 디테일 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "fs5th-team1-docthru",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.5",
+        "@fontsource/orbitron": "^5.2.5",
         "@tanstack/react-query": "^5.69.0",
         "@tanstack/react-query-devtools": "^5.69.0",
         "axios": "^1.8.4",
@@ -22,6 +24,7 @@
         "react-hot-toast": "^2.5.2",
         "react-markdown": "^10.1.0",
         "react-quill-new": "^3.4.6",
+        "react-simple-typewriter": "^5.0.1",
         "react-syntax-highlighter": "^15.6.1",
         "remark-gfm": "^4.0.1",
         "tailwind-scrollbar-hide": "^2.0.0",
@@ -1032,6 +1035,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.5.tgz",
+      "integrity": "sha512-TPZ9b/uq38RMdrlZZkl0RwN8Ju9JxuqMETrw76pUQFbGtE1QbwQaNsLlnUrACNNBNbd0NZRXiJJSkC8ajPgbew==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/orbitron": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/orbitron/-/orbitron-5.2.5.tgz",
+      "integrity": "sha512-e3164ITI9u27irFN4tszwj/OIA9q/TIGKWJ6NUEDvziRO3/9RfnJjioBRyLW6lpslu+oV6US/17bNGlMfZqr5A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {
@@ -10947,6 +10968,19 @@
         "quill-delta": "^5.1.0",
         "react": "^16 || ^17 || ^18 || ^19",
         "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-simple-typewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-5.0.1.tgz",
+      "integrity": "sha512-vA5HkABwJKL/DJ4RshSlY/igdr+FiVY4MLsSQYJX6FZG/f1/VwN4y1i3mPXRyfaswrvI8xii1kOVe1dYtO2Row==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "**/*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.5",
+    "@fontsource/orbitron": "^5.2.5",
     "@tanstack/react-query": "^5.69.0",
     "@tanstack/react-query-devtools": "^5.69.0",
     "axios": "^1.8.4",
@@ -30,6 +32,7 @@
     "react-hot-toast": "^2.5.2",
     "react-markdown": "^10.1.0",
     "react-quill-new": "^3.4.6",
+    "react-simple-typewriter": "^5.0.1",
     "react-syntax-highlighter": "^15.6.1",
     "remark-gfm": "^4.0.1",
     "tailwind-scrollbar-hide": "^2.0.0",

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -24,6 +24,10 @@ export const useLogin = () => {
           router.replace(PATH.challenge);
         }
       },
+      onError: () => {
+        // 전역에서 또 토스트 띄우지 않도록 방지
+        return true;
+      },
     },
     'login-toast'
   );

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -66,6 +66,10 @@ export const useSignup = () => {
       onSuccess: () => {
         router.push('/auth/login');
       },
+      onError: () => {
+        // 전역 토스트 중복 방지
+        return true;
+      },
     },
     'signup-toast'
   );

--- a/src/api/url.ts
+++ b/src/api/url.ts
@@ -62,20 +62,25 @@ export const customFetch = async (
     //   window.location.href = '/auth/login';
     // }
   };
+  const getSafeMessage = (data: any, fallback: string) => {
+    if (!data) return fallback;
+    if (typeof data === 'string') return data;
+    if (typeof data.message === 'string') return data.message;
+    return JSON.stringify(data);
+  };
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
+    const message = getSafeMessage(errorData, '요청에 실패했습니다.');
 
-    if (response.status === 401) {
-      handleAuthError(errorData.message || '로그인이 필요합니다.');
-    } else if (response.status === 419) {
-      handleAuthError(errorData.message || '세션이 만료되었습니다.');
+    if ([401, 419].includes(response.status)) {
+      handleAuthError(message);
     } else if (response.status === 403) {
-      toast.error(errorData.message || '접근 권한이 없습니다.');
+      toast.error(message);
     } else {
-      toast.error(errorData.message || '요청에 실패했습니다.');
+      toast.error(message);
     }
 
-    throw new Error(errorData.message || '요청에 실패했습니다.');
+    throw new Error(message); // 항상 string만 throw
   }
 
   return response;

--- a/src/app/notification/components/ProfileCard.tsx
+++ b/src/app/notification/components/ProfileCard.tsx
@@ -7,6 +7,7 @@ export default function ProfileCard() {
   const hasHydrated = useHydrated();
 
   if (!hasHydrated) return null;
+  const isAdmin = user?.role === 'ADMIN';
   if (!user)
     return <div className="text-center mt-10">로그인이 필요합니다.</div>;
 
@@ -22,7 +23,11 @@ export default function ProfileCard() {
         </p>
         <p>
           <strong>Role:</strong>{' '}
-          {user.role === 'ADMIN' ? '관리자' : '일반 사용자'}
+          {isAdmin
+            ? '관리자'
+            : user.rank === 'EXPERT'
+              ? '전문가'
+              : '일반 사용자'}
         </p>
       </div>
     </div>

--- a/src/app/notification/components/ProfileCard.tsx
+++ b/src/app/notification/components/ProfileCard.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useAuthStore, useHydrated } from '@/api/auth/AuthStore';
+
+export default function ProfileCard() {
+  const { user } = useAuthStore();
+  const hasHydrated = useHydrated();
+
+  if (!hasHydrated) return null;
+  if (!user)
+    return <div className="text-center mt-10">로그인이 필요합니다.</div>;
+
+  return (
+    <div className="max-w-xl mx-auto mt-10 border p-6 rounded-lg shadow">
+      <h1 className="text-2xl font-bold mb-4">My Profile</h1>
+      <div className="space-y-2">
+        <p>
+          <strong>닉네임:</strong> {user.nickname}
+        </p>
+        <p>
+          <strong>E-mail:</strong> {user.email}
+        </p>
+        <p>
+          <strong>Role:</strong>{' '}
+          {user.role === 'ADMIN' ? '관리자' : '일반 사용자'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -6,6 +6,7 @@ import {
   Notification,
   deleteNotification,
 } from '@/api/notification/notification.api';
+import ProfileCard from './components/ProfileCard';
 
 export default function NotificationPage() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
@@ -30,33 +31,36 @@ export default function NotificationPage() {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-4">
-      <h1 className="text-xl font-bold mb-4">📬 알림 목록</h1>
-      {notifications.length === 0 ? (
-        <p className="text-gray-500">알림이 없습니다.</p>
-      ) : (
-        <ul className="space-y-4">
-          {notifications.map((n) => (
-            <li
-              key={n.id}
-              className="bg-white border p-4 rounded shadow relative"
-            >
-              <p className="text-gray-800">{n.message}</p>
-              <div className="flex justify-between items-center mt-2">
-                <p className="text-sm text-gray-400">
-                  {new Date(n.createdAt).toLocaleString('ko-KR')}
-                </p>
-                <button
-                  onClick={() => handleDelete(n.id)}
-                  className="text-[12px] text-gray-400 underline hover:text-red-500"
-                >
-                  삭제
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <>
+      <ProfileCard />
+      <div className=" max-w-xl mx-auto p-4">
+        <h1 className="text-xl font-bold my-4">📬 알림 목록</h1>
+        {notifications.length === 0 ? (
+          <p className="text-gray-500">알림이 없습니다.</p>
+        ) : (
+          <ul className="space-y-4">
+            {notifications.map((n) => (
+              <li
+                key={n.id}
+                className="bg-white border p-4 rounded shadow relative"
+              >
+                <p className="text-gray-800">{n.message}</p>
+                <div className="flex justify-between items-center mt-2">
+                  <p className="text-sm text-gray-400">
+                    {new Date(n.createdAt).toLocaleString('ko-KR')}
+                  </p>
+                  <button
+                    onClick={() => handleDelete(n.id)}
+                    className="text-[12px] text-gray-400 underline hover:text-red-500"
+                  >
+                    삭제
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,30 +2,32 @@
 'use client';
 //랜딩페이지로 수정했어요
 import { motion } from 'framer-motion';
+import { Typewriter } from 'react-simple-typewriter';
 import Link from 'next/link';
 export default function Home() {
   //redirect('/main/challenge');
   return (
     <div className="w-screen min-h-screen bg-black text-white flex flex-col justify-center items-center">
       {/* 터미널 스타일 */}
-      <div className="font-mono text-green-400 text-sm md:text-base">
+      <div className="dev-font text-green-400 text-sm md:text-base">
         <p className="mb-1">{'>'} Initializing journey...</p>
         <p className="mb-1 animate-pulse">{'>'} Connecting to Docthru...</p>
         <p className="mb-4">{'>'} Access granted.</p>
       </div>
 
       {/* 로고  */}
-      <motion.h1
-        className="text-4xl md:text-6xl font-extrabold text-center"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1 }}
-      >
-        Docthru
-      </motion.h1>
+      <h1 className="text-4xl md:text-6xl font-extrabold text-center font-[quantico] text-white glow">
+        <Typewriter
+          words={['Docthru']}
+          loop={1}
+          cursor
+          cursorStyle="|"
+          typeSpeed={180}
+        />
+      </h1>
       {/* Through the docs, to the dev. (docs로부터 개발자로 가는 여정) 괜찮나요?( @@ )ノ💻 */}
       <motion.p
-        className="text-lg md:text-2xl text-center m-4 text-gray-300"
+        className="text-lg md:text-2xl text-center m-4 text-gray-300 "
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 1, duration: 1 }}

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -117,7 +117,7 @@ export const Card = ({ data, status, onClick }: CardProps) => {
           </p>
           <Image src={personIcon} alt="person Icon" width={16} height={16} />
           <p className="text-sm font-normal text-custom-gray-600">
-            {data.currentParticipants}/{data.maxParticipants}
+            {data.currentParticipants}/{data.maxParticipants} 참여중
           </p>
         </div>
 

--- a/src/shared/components/dropdown/ProfileDropdown.tsx
+++ b/src/shared/components/dropdown/ProfileDropdown.tsx
@@ -54,7 +54,13 @@ const ProfileDropdown = () => {
               >
                 {user.nickname}
               </p>
-              <p className="text-xs text-gray-500">{user.role}</p>
+              <p className="text-xs text-gray-500">
+                {isAdmin
+                  ? '관리자'
+                  : user.rank === 'EXPERT'
+                    ? '전문가'
+                    : '일반 사용자'}
+              </p>
             </div>
           </div>
           <hr className="my-2" />

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 import Logo from '@/shared/Img/logo.svg';
 import Image from 'next/image';
 //import BassBell from '@/shared/Img/bell-icon/bass.svg';
-import { Divider } from '../Divider';
+// import { Divider } from '../Divider';
 import { useRouter } from 'next/navigation';
 import { PATH } from '@/constants';
 import { useAuthStore, useHydrated } from '@/api/auth/AuthStore';
@@ -79,8 +79,8 @@ const Header = () => {
           <ProfileDropdown />
         )}
       </div>
-
-      <Divider />
+      {/* 
+      <Divider /> */}
     </div>
   );
 };

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 import Logo from '@/shared/Img/logo.svg';
 import Image from 'next/image';
 //import BassBell from '@/shared/Img/bell-icon/bass.svg';
-// import { Divider } from '../Divider';
+import { Divider } from '../Divider';
 import { useRouter } from 'next/navigation';
 import { PATH } from '@/constants';
 import { useAuthStore, useHydrated } from '@/api/auth/AuthStore';
@@ -42,7 +42,7 @@ const Header = () => {
   };
 
   return (
-    <div className="w-full flex flex-col items-center justify-center">
+    <div className="w-full bg-white flex flex-col items-center justify-center border-b border-solid border-[#E5E5E5]">
       <div className="max-w-[1200px] w-full h-15 bg-white flex items-center justify-between md:px-6 px-4  lg:py-[14px]">
         <div className="flex gap-6">
           <Image
@@ -79,8 +79,8 @@ const Header = () => {
           <ProfileDropdown />
         )}
       </div>
-      {/* 
-      <Divider /> */}
+
+      {/* <Divider /> */}
     </div>
   );
 };

--- a/src/shared/components/popup/popup.tsx
+++ b/src/shared/components/popup/popup.tsx
@@ -16,33 +16,34 @@ const Popup: React.FC<PopupProps> = ({ isOpen, notifications, onDelete }) => {
   return (
     <div className="absolute right-0 top-6 z-50">
       <div className="relative bg-white rounded-xl border-2 border-custom-gray-300 shadow-lg py-3 m-4 w-90 max-h-115">
-        <div className="flex justify-between items-center pb-2 mb-4">
-          <h3 className="text-lg font-bold px-3">알림</h3>
+        <div className="flex justify-between items-center pb-2 mb-2">
+          <h3 className="text-lg font-bold px-4 ">알림</h3>
         </div>
         <div className="max-h-[390px] overflow-y-auto custom-scrollbar">
           {notifications.length === 0 ? (
-            <p className="text-gray-500">알림이 없습니다.</p>
+            <p className="text-gray-500 px-3 ">알림이 없습니다.</p>
           ) : (
             notifications.map((notification) => (
-              <div key={notification.id} className="px-3 mb-3 border-b pb-2">
+              <div key={notification.id} className="px-3 mb-3 border-b py-2">
                 <p className="text-gray-800">{notification.message}</p>
-
-                <p className="text-gray-400 text-sm mt-2 ml-1">
-                  {new Date(notification.createdAt).toLocaleString('ko-KR', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: true,
-                  })}{' '}
+                <div className="flex justify-between px-2">
+                  <p className="text-gray-400 text-sm mt-2 ml-1">
+                    {new Date(notification.createdAt).toLocaleString('ko-KR', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                      // hour: '2-digit',
+                      // minute: '2-digit',
+                      // hour12: true,
+                    })}{' '}
+                  </p>
                   <button
                     onClick={() => onDelete(notification.id)}
-                    className="underline ml-1 text-[12px] text-gray-500 hover:text-red-500 cursor-pointer"
+                    className="underline ml-1 text-[13px] text-gray-500 hover:text-red-500 cursor-pointer"
                   >
                     삭제
                   </button>
-                </p>
+                </div>
               </div>
             ))
           )}

--- a/src/shared/components/popup/popup.tsx
+++ b/src/shared/components/popup/popup.tsx
@@ -15,19 +15,19 @@ const Popup: React.FC<PopupProps> = ({ isOpen, notifications, onDelete }) => {
 
   return (
     <div className="absolute right-0 top-6 z-50">
-      <div className="relative bg-white rounded shadow-lg p-4 m-4 w-80 max-h-116">
-        <div className="flex justify-between items-center border-b pb-2 mb-4">
-          <h3 className="text-lg font-bold">알림</h3>
+      <div className="relative bg-white rounded-xl border-2 border-custom-gray-300 shadow-lg py-3 m-4 w-90 max-h-115">
+        <div className="flex justify-between items-center pb-2 mb-4">
+          <h3 className="text-lg font-bold px-3">알림</h3>
         </div>
-        <div className="max-h-60 overflow-y-auto">
+        <div className="max-h-[390px] overflow-y-auto custom-scrollbar">
           {notifications.length === 0 ? (
             <p className="text-gray-500">알림이 없습니다.</p>
           ) : (
             notifications.map((notification) => (
-              <div key={notification.id} className="mb-3 border-b pb-2">
+              <div key={notification.id} className="px-3 mb-3 border-b pb-2">
                 <p className="text-gray-800">{notification.message}</p>
 
-                <p className="text-gray-500 text-sm mt-1 ml-1">
+                <p className="text-gray-400 text-sm mt-2 ml-1">
                   {new Date(notification.createdAt).toLocaleString('ko-KR', {
                     year: 'numeric',
                     month: '2-digit',
@@ -38,7 +38,7 @@ const Popup: React.FC<PopupProps> = ({ isOpen, notifications, onDelete }) => {
                   })}{' '}
                   <button
                     onClick={() => onDelete(notification.id)}
-                    className="underline ml-1 text-[12px] text-gray-400 hover:text-red-500 cursor-pointer"
+                    className="underline ml-1 text-[12px] text-gray-500 hover:text-red-500 cursor-pointer"
                   >
                     삭제
                   </button>

--- a/src/shared/components/tab/Tab.tsx
+++ b/src/shared/components/tab/Tab.tsx
@@ -32,21 +32,20 @@ export const Tab = ({ position, isActive, children, ...props }: TabProps) => {
   const TextColorStyle = TabColorStyle[isActive];
   const borderStyle =
     position === TextPosition.MIDDLE && isActive === TabActive.ON
-      ? 'border-b-2 border-black'
+      ? 'border-b-2 border-custom-gray-800'
       : '';
+  const fullClassName =
+    `cursor-pointer ${baseStyle} ${TextColorStyle} ${borderStyle}`.trim();
 
   if (position === 'top') {
     return (
-      <button className={`${baseStyle} ${TextColorStyle}`} {...props}>
+      <button className={fullClassName} {...props}>
         {children}
       </button>
     );
   }
   return (
-    <button
-      className={`${baseStyle} ${TextColorStyle}  ${borderStyle}`}
-      {...props}
-    >
+    <button className={fullClassName} {...props}>
       {children}
     </button>
   );

--- a/src/shared/globals.css
+++ b/src/shared/globals.css
@@ -41,6 +41,7 @@
 @layer base {
   body {
     font-family: 'pretendard', 'quantico';
+    background-color: #f5f5f5;
   }
   *,
   ::after,
@@ -59,6 +60,20 @@
   * 가운데 숫자는 font-size
   * 마지막 숫자는 line-height
 */
+/* Custom scrollbar */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.15); /* 반투명한 회색 */
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
 .SB-24-0 {
   font-weight: 600;
   font-size: 24px;

--- a/src/shared/globals.css
+++ b/src/shared/globals.css
@@ -2,6 +2,7 @@
 @import 'react-quill-new/dist/quill.snow.css';
 
 /*여기에 폰트 넣으시면 됩니다.*/
+@import '@fontsource/jetbrains-mono';
 @font-face {
   font-family: 'pretendard';
   font-style: normal;
@@ -43,6 +44,9 @@
     font-family: 'pretendard', 'quantico';
     background-color: #f5f5f5;
   }
+  .dev-font {
+    font-family: 'JetBrains Mono', monospace;
+  }
   *,
   ::after,
   ::before,
@@ -65,6 +69,30 @@
   width: 6px;
 }
 
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    border-color: transparent;
+  }
+  50% {
+    border-color: #facc15;
+  }
+}
+
+.glow {
+  text-shadow:
+    0 0 4px #facc15,
+    0 0 10px #facc15;
+}
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.15); /* 반투명한 회색 */
   border-radius: 4px;

--- a/src/shared/hooks/useToastMutation.ts
+++ b/src/shared/hooks/useToastMutation.ts
@@ -3,7 +3,7 @@ import {
   UseMutationOptions,
   UseMutationResult,
 } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
+// import { isAxiosError } from 'axios';
 
 import toast from 'react-hot-toast';
 
@@ -48,19 +48,24 @@ export function useToastMutation<
     onError: (error, variables, context) => {
       if (toastId) toast.dismiss(toastId);
 
+      // 사용하는 곳에서 true를 리턴하면 전역 토스트는 건너뜀
+      const isHandled = options?.onError?.(error, variables, context);
+      if (isHandled === true) return;
+
       let serverErrorMessage = '문제가 발생했습니다. 다시 시도해주세요.';
 
-      if (isAxiosError(error)) {
-        serverErrorMessage =
-          error.response?.data?.message ?? serverErrorMessage;
+      if (error instanceof Error) {
+        serverErrorMessage = error.message;
+      } else if (typeof error === 'object' && error && 'message' in error) {
+        serverErrorMessage = (error as any).message;
       }
 
       toast.error(serverErrorMessage, {
         id: toastId,
         duration: 3000,
       });
-      options?.onError?.(error, variables, context);
     },
+
     onSettled: (data, error, variables, context) => {
       options?.onSettled?.(data, error, variables, context);
     },

--- a/src/shared/hooks/useToastMutation.ts
+++ b/src/shared/hooks/useToastMutation.ts
@@ -3,7 +3,7 @@ import {
   UseMutationOptions,
   UseMutationResult,
 } from '@tanstack/react-query';
-// import { isAxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 
 import toast from 'react-hot-toast';
 
@@ -54,16 +54,16 @@ export function useToastMutation<
 
       let serverErrorMessage = '문제가 발생했습니다. 다시 시도해주세요.';
 
-      if (error instanceof Error) {
-        serverErrorMessage = error.message;
-      } else if (typeof error === 'object' && error && 'message' in error) {
-        serverErrorMessage = (error as any).message;
+      if (isAxiosError(error)) {
+        serverErrorMessage =
+          error.response?.data?.message ?? serverErrorMessage;
       }
 
       toast.error(serverErrorMessage, {
         id: toastId,
         duration: 3000,
       });
+      options?.onError?.(error, variables, context);
     },
 
     onSettled: (data, error, variables, context) => {


### PR DESCRIPTION
## 📌 개요

- 로그인 실패시 데이터 초기화 및 토스트 두개 뜨는문제 해결
- 곳곳에 눈에 보이는 UI 디테일들 작업함

## ✨ 주요 변경 사항

- tab 컴포넌트에 cursor-pointer 옵션 추가했습니다.
- 헤더와 바디가 divider 컴포넌트로 분리되어있었는데 시안을 자세히 보니 body에 색상이 적용되어 있어서 global CSS에서 색상 적용하였고 header 컴포넌트에서 divider 제거하고 (divider 색상이 진해서) border-b 처리하였습니다. 
- 알림 popup 컴포넌트도 디자인 수정 조금 하였습니다. 커스톰 스크롤바 적용 등
- 랜딩페이지 폰트 날라간 것 복구 및 업그레이드 시켰습니다.
- 로그인 실패시 토스트 두개 뜨고 새로고침되면서 데이터 초기화 되는 문제 트래킹하여 해결하였습니다. 
- 회원가입 페이지에서도 동일한 버그가 있어서 토스트 하나만 뜨도록 수정했습니다. 

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 새로고침되는 문제는 리다이렉트 되는것 같아서 리다이렉트시키는 코드 (window.location.href) 검색해서 주석처리하니까 해결되었는데, 이렇게 해결하는게 정답인지는 모르겠습니다. 나머지 인증과 관련된 문제는 노션 정리했습니다. https://www.notion.so/1cf36713bdaf80c79aa7ff47b09b3bc9?pvs=4

## 🔗 관련 이슈

- #121 

## 스크린샷
![image](https://github.com/user-attachments/assets/9063f5f5-d9d0-4abd-9a0a-e8d2572f3a78)
![Screenshot 2025-04-13 at 01 54 14](https://github.com/user-attachments/assets/4dae669d-5bae-4186-9bc0-6770e0d24155)
![image](https://github.com/user-attachments/assets/e22835c1-5a7e-4981-b445-deaf5fb19906)
