### PR TITLE
카드 수정, 페이지 카드 들어갈 시 개수 수정, 배경색 분기처리

### DIFF
--- a/src/api/challenge/ChallengeApi.ts
+++ b/src/api/challenge/ChallengeApi.ts
@@ -108,6 +108,18 @@ export const editChallenge = async (id: string, data: ChallengeFormRequest) => {
   return res.json();
 };
 
+export const editChallengeByAdmin = async (
+  id: string,
+  data: ChallengeFormRequest
+) => {
+  const res = await customFetch(`/challenges/${id}/admin/modify`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+};
+
 export const deleteChallenge = async (id: string) => {
   const res = await customFetch(`/challenges/${id}/remove`, {
     method: 'PATCH',
@@ -115,9 +127,13 @@ export const deleteChallenge = async (id: string) => {
   return res.json();
 };
 
-export const deleteChallengeByAdmin = async (id: string) => {
-  const res = await customFetch(`/challenges/${id}/removeForce`, {
+export const deleteChallengeByAdmin = async (id: string, reason: string) => {
+  const res = await customFetch(`/challenges/${id}/admin/removeForce`, {
     method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ deletedReason: reason }),
   });
   return res.json();
 };

--- a/src/api/challenge/ChallengeHooks.ts
+++ b/src/api/challenge/ChallengeHooks.ts
@@ -11,6 +11,7 @@ import {
   approveChallenge,
   rejectChallenge,
   deleteChallenge,
+  deleteChallengeByAdmin,
 } from './ChallengeApi';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -124,6 +125,28 @@ export const useDeleteChallenge = (id: string) => {
       onSuccess,
     },
     'deleteChallenge-toast'
+  );
+
+  return { deleteMutation };
+};
+
+export const useDeleteChallengeByAdmin = () => {
+  const queryClient = useQueryClient();
+
+  const onSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: ['challenges'] });
+    queryClient.invalidateQueries({ queryKey: ['my-challenges'] });
+  };
+
+  const deleteMutation = useToastMutation<{ id: string; reason: string }, void>(
+    ({ id, reason }) => deleteChallengeByAdmin(id, reason),
+    {
+      success: '챌린지 삭제 완료!',
+    },
+    {
+      onSuccess,
+    },
+    'deleteChallengeByAdmin-toast'
   );
 
   return { deleteMutation };

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -10,7 +10,7 @@ export default function AuthLayout({
   return (
     <ReactQueryProvider>
       <ToastProvider />
-      <section className="flex flex-col justify-center items-center px-4 md:px-28  gap-10 ">
+      <section className="flex flex-col h-screen  items-center px-4 md:px-28  bg-[#f5f5f5] ">
         {children}
       </section>
     </ReactQueryProvider>

--- a/src/app/main/challenge/_components/ChallengeHead.tsx
+++ b/src/app/main/challenge/_components/ChallengeHead.tsx
@@ -10,7 +10,7 @@ export default function ChallengeHead() {
   const isAdmin = user.role === 'ADMIN';
 
   return (
-    <div className="flex justify-between items-center">
+    <div className="flex justify-between items-center bg-custom-gray-50">
       <p className="text-xl text-custom-gray-800 font-semibold ">챌린지 목록</p>
       {!isAdmin && (
         <div className="flex">

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { Card } from '@/shared/components/card/Card';
 import Search from '@/shared/components/input/search';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Pagination from './Pagination';
 import { Filter } from '@/shared/components/dropdown/Filter';
 import { useToastQuery } from '@/shared/hooks/useToastQuery';
 import { fetchChallenges } from '@/api/challenge/ChallengeApi';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import CardSkeleton from '@/shared/components/card/CardSkeleton';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
+import { useDeleteChallengeByAdmin } from '@/api/challenge/ChallengeHooks';
+import { PATH } from '@/constants';
 
 const ChallengeMain = () => {
   const [keyword, setKeyword] = useState('');
@@ -21,6 +23,7 @@ const ChallengeMain = () => {
   const isMobile = useMediaQuery('(max-width: 344px)');
   const displayCount = isMobile ? 4 : 5;
 
+  const router = useRouter();
   const searchParams = useSearchParams();
   const initialPage = Number(searchParams.get('page')) || 1;
   const [page, setPage] = useState(initialPage);
@@ -45,6 +48,12 @@ const ChallengeMain = () => {
       keepPreviousData: true,
     }
   );
+
+  const { deleteMutation } = useDeleteChallengeByAdmin();
+
+  const handleDelete = (id: string, reason: string) => {
+    deleteMutation.mutate({ id, reason });
+  };
 
   const challenges = data?.challenges ?? [];
   const totalCount = data?.totalCount ?? 0;
@@ -107,6 +116,10 @@ const ChallengeMain = () => {
                     ? 'PENDING'
                     : challenge.approvalStatus,
               }}
+              onEdit={(id) => {
+                router.push(`${PATH.challenge}/${id}/edit`);
+              }}
+              onDelete={handleDelete}
             />
           ))
         )}

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -62,7 +62,7 @@ const ChallengeMain = () => {
   }, [page]);
 
   return (
-    <div className="flex flex-col gap-6 ">
+    <div className="flex flex-col gap-6 bg-custom-gray-50">
       <section className="flex gap-3">
         <div className="flex items-center">
           <Filter

--- a/src/app/main/challenge/_components/Pagination.tsx
+++ b/src/app/main/challenge/_components/Pagination.tsx
@@ -45,7 +45,7 @@ const Pagination = ({
         />
       </button>
 
-      <div>
+      <div className="flex gap-1.5">
         {pageNumbers.map((page) => (
           <button
             key={page}
@@ -54,7 +54,7 @@ const Pagination = ({
               ${
                 page === currentPage
                   ? 'bg-custom-gray-800 text-custom-yellow-brand'
-                  : 'bg-white text-custom-gray-400 hover:text-custom-gray-800 hover:font-semibold'
+                  : ' text-custom-gray-400 hover:text-custom-gray-800 hover:font-semibold'
               }`}
           >
             {page}

--- a/src/app/main/my-challenge/components/MyChallengeMain.tsx
+++ b/src/app/main/my-challenge/components/MyChallengeMain.tsx
@@ -17,6 +17,7 @@ import { Card } from '@/shared/components/card/Card';
 import { useSearchParams } from 'next/navigation';
 import CardSkeleton from '@/shared/components/card/CardSkeleton';
 import ChallengeTable from './ChallengeTable';
+import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
 
 const TAB_LIST = [
   { key: 'participating', label: '참여중인 챌린지' },
@@ -37,12 +38,13 @@ type Params = {
 };
 
 const MyChallengeMain = () => {
-  const [limit] = useState(10);
   const [totalPages, setTotalPages] = useState(1);
   const [keyword, setKeyword] = useState('');
   const [activeTab, setActiveTab] = useState<TabKey>('participating');
   const [sortValue, setSortValue] = useState('option1');
 
+  const isMobile = useMediaQuery('(max-width: 344px)');
+  const limit = activeTab === 'applied' ? 10 : isMobile ? 4 : 5;
   const searchParams = useSearchParams();
   const initialPage = Number(searchParams.get('page')) || 1;
   const [page, setPage] = useState(initialPage);
@@ -219,7 +221,7 @@ const MyChallengeMain = () => {
 
       <section className="flex flex-col gap-6 w-full">
         {isPending ? (
-          Array.from({ length: 5 }).map((_, index) => (
+          Array.from({ length: limit }).map((_, index) => (
             <CardSkeleton key={index} />
           ))
         ) : challenges.length === 0 ? (

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -81,7 +81,7 @@ export const Card = ({ data, status, onClick }: CardProps) => {
   return (
     <div
       onClick={handleClick}
-      className="flex flex-col  w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 cursor-pointer  transition-transform duration-300 hover:scale-105 "
+      className="flex flex-col  w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 cursor-pointer  transition-transform duration-300 hover:scale-105 bg-white"
     >
       <section className="flex w-full justify-between relative">
         <div className="flex flex-col gap-4 ">

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -10,11 +10,6 @@ import { PATH } from '@/constants';
 import Button, { ButtonCategory } from '../button/Button';
 import { CardSelector } from './CardSelector';
 import { useAuthStore } from '@/api/auth/AuthStore';
-import {
-  deleteChallenge,
-  deleteChallengeByAdmin,
-} from '@/api/challenge/ChallengeApi';
-import toast from 'react-hot-toast';
 
 export interface CardData {
   id: string;
@@ -34,11 +29,18 @@ export interface CardData {
 export interface CardProps {
   data: CardData;
   status?: 'participating' | 'completed' | 'applied';
-
   onClick?: () => void;
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string, reason: string) => void;
 }
 
-export const Card = ({ data, status, onClick }: CardProps) => {
+export const Card = ({
+  data,
+  status,
+  onClick,
+  onEdit,
+  onDelete,
+}: CardProps) => {
   const { user } = useAuthStore();
   const router = useRouter();
 
@@ -51,21 +53,6 @@ export const Card = ({ data, status, onClick }: CardProps) => {
   const handleClick = () => {
     if (onClick) return onClick();
     router.push(`${PATH.challenge}/${data.id}`);
-  };
-
-  const handleEdit = () => router.push(`${PATH.challenge}/${data.id}/edit`);
-
-  const handleDelete = async () => {
-    try {
-      if (isAdmin) {
-        await deleteChallengeByAdmin(data.id);
-      } else {
-        await deleteChallenge(data.id);
-      }
-      router.refresh();
-    } catch {
-      toast.error('삭제 중 오류가 발생했습니다.');
-    }
   };
 
   const handleRoute = () => {
@@ -101,9 +88,12 @@ export const Card = ({ data, status, onClick }: CardProps) => {
             <Chip label={data.documentType} />
           </div>
         </div>
-        {isShowSelector && (
+        {isShowSelector && onDelete && onEdit && (
           <>
-            <CardSelector onEdit={handleEdit} onDelete={handleDelete} />
+            <CardSelector
+              onEdit={() => onEdit(data.id)}
+              onDelete={(reason) => onDelete(data.id, reason)}
+            />
           </>
         )}
       </section>

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -81,7 +81,7 @@ export const Card = ({ data, status, onClick }: CardProps) => {
   return (
     <div
       onClick={handleClick}
-      className="flex flex-col  w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 cursor-pointer "
+      className="flex flex-col  w-full justify-center items-center rounded-2xl border-2 border-custom-gray-800 gap-4 p-6 cursor-pointer  transition-transform duration-300 hover:scale-105 "
     >
       <section className="flex w-full justify-between relative">
         <div className="flex flex-col gap-4 ">

--- a/src/shared/components/card/CardSelector.tsx
+++ b/src/shared/components/card/CardSelector.tsx
@@ -2,15 +2,17 @@ import Image from 'next/image';
 import selectorIcon from '@images/menu-icon/Meatballs.svg';
 import { useState } from 'react';
 import { useAuthStore } from '@/api/auth/AuthStore';
+import SendModal from '../modal/send';
 
 export const CardSelector = ({
   onEdit,
   onDelete,
 }: {
   onEdit: () => void;
-  onDelete: () => void;
+  onDelete: (reason: string) => void;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { user } = useAuthStore();
 
   const toggleMenu = (e: React.MouseEvent) => {
@@ -44,7 +46,11 @@ export const CardSelector = ({
               수정하기
             </li>
             <li
-              onClick={handleAction(onDelete)}
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsDeleteModalOpen(true);
+                setIsOpen(false);
+              }}
               className="py-3 px-11 text-custom-gray-500  cursor-pointer "
             >
               삭제하기
@@ -52,6 +58,28 @@ export const CardSelector = ({
           </ul>
         )}
       </div>
+
+      {isDeleteModalOpen && (
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            if (e.nativeEvent.stopImmediatePropagation) {
+              e.nativeEvent.stopImmediatePropagation();
+            }
+          }}
+        >
+          <SendModal
+            isOpen={isDeleteModalOpen}
+            onClose={() => setIsDeleteModalOpen(false)}
+            onSend={(reason) => {
+              onDelete(reason);
+              setIsDeleteModalOpen(false);
+            }}
+            title="삭제 사유"
+            placeholder="삭제 사유를 입력해주세요"
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/src/shared/components/dropdown/Filter.tsx
+++ b/src/shared/components/dropdown/Filter.tsx
@@ -67,7 +67,7 @@ export const Filter: React.FC<FilterProps> = ({ textSize, onApply }) => {
       className={`w-[140px] h-10 relative ${textSize === 'lg' ? 'R-14-0' : 'R-13-0'}`}
     >
       <div
-        className={`${selectBoxStyle} p-3 pl-3 pr-2 color ${filterCount !== 0 ? 'bg-custom-gray-800 text-custom-gray-50' : 'text-custom-gray-400'}`}
+        className={`${selectBoxStyle} p-3 pl-3 pr-2 color ${filterCount !== 0 ? 'bg-custom-gray-800 text-custom-gray-50' : 'text-custom-gray-400 bg-white'}`}
         onClick={handleButtonClick}
       >
         {`필터  ${filterCount !== 0 ? filterCount : ''}`}

--- a/src/shared/components/form/AuthForm.tsx
+++ b/src/shared/components/form/AuthForm.tsx
@@ -8,6 +8,7 @@ import Password from '../input/password';
 import Text from '../input/text';
 import Link from 'next/link';
 import { useFormContext, SubmitHandler } from 'react-hook-form';
+import { PATH } from '@/constants';
 
 export interface AuthFormData {
   email: string;
@@ -34,8 +35,8 @@ const AuthForm = ({ category, onSubmit, isPending }: AuthFormProps) => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <section>
         <Link
-          href={'/'}
-          className="flex justify-center items-center pt-32 gap-3.5"
+          href={PATH.challenge}
+          className="flex justify-center items-center pt-32 gap-3.5 "
         >
           <Image src={mainLogo} alt="main logo" />
         </Link>

--- a/src/shared/components/input/date.tsx
+++ b/src/shared/components/input/date.tsx
@@ -19,7 +19,7 @@ const Date = <T extends FieldValues>({
         type="date"
         {...register(name)}
         placeholder={placeholder}
-        className={`mb-3 h-12 rounded-xl border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-500 ${size}`}
+        className={`mb-3 h-12 rounded-xl bg-white border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-500 ${size}`}
       />
     </div>
   );

--- a/src/shared/components/input/email.tsx
+++ b/src/shared/components/input/email.tsx
@@ -32,7 +32,7 @@ const Email = <T extends FieldValues>({
           },
         })}
         placeholder={placeholder}
-        className={`p-3.5 pr-9 border rounded-xl focus:outline-none focus:ring-1 ${size} ${
+        className={`p-3.5 pr-9 border bg-white rounded-xl focus:outline-none focus:ring-1 ${size} ${
           errors && errors[name]
             ? 'border-red-500 focus:ring-red-500'
             : 'border-custom-gray-200 focus:ring-custom-gray-200'

--- a/src/shared/components/input/password.tsx
+++ b/src/shared/components/input/password.tsx
@@ -51,12 +51,12 @@ const Password = <T extends FieldValues>({
   }
 
   return (
-    <div className="inline-block relative">
+    <div className="inline-block relative ">
       <input
         type={showPassword ? 'text' : 'password'}
         {...register(name, validationMessages)}
         placeholder={placeholder}
-        className={`p-3.5 pr-9 border rounded-xl focus:outline-none focus:ring-1 ${size} ${
+        className={`p-3.5 pr-9 border  bg-white rounded-xl focus:outline-none focus:ring-1 ${size} ${
           errors && errors[name]
             ? 'border-red-500 focus:ring-red-500'
             : 'border-custom-gray-200 focus:ring-custom-gray-200'

--- a/src/shared/components/input/search.tsx
+++ b/src/shared/components/input/search.tsx
@@ -33,7 +33,7 @@ const Search: FC<SearchInputProps> = ({
   };
 
   return (
-    <div className="relative">
+    <div className="relative bg-white">
       <input
         type="search"
         name={name}

--- a/src/shared/components/input/text.tsx
+++ b/src/shared/components/input/text.tsx
@@ -30,14 +30,14 @@ const Text = <T extends FieldValues>({
         <textarea
           {...register(name, rules)}
           placeholder={placeholder}
-          className={`leading-none resize-none p-[14px] border rounded-[6px] focus:outline-none focus:ring-2 focus:ring-custom-gray-200 ${size}`}
+          className={`leading-none resize-none p-[14px] bg-white border rounded-[6px] focus:outline-none focus:ring-2 focus:ring-custom-gray-200 ${size}`}
         />
       ) : (
         <input
           type={type}
           {...register(name, rules)}
           placeholder={placeholder}
-          className={`leading-none resize-none p-[14px] border rounded-[6px] focus:outline-none focus:ring-2 focus:ring-custom-gray-200 ${size}`}
+          className={`leading-none resize-none p-[14px] bg-white border rounded-[6px] focus:outline-none focus:ring-2 focus:ring-custom-gray-200 ${size}`}
         />
       )}
       {errorMessage && (

--- a/src/shared/components/layout/Layout.tsx
+++ b/src/shared/components/layout/Layout.tsx
@@ -2,13 +2,23 @@
 
 import Header from './Header';
 import Footer from './Footer';
+import { usePathname } from 'next/navigation';
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
+  const pathname = usePathname();
+  const pagesWithGrayBg = ['/main/challenge', '/main/my-challenge'];
+  const isGrayBackgroundPage = pagesWithGrayBg.includes(pathname);
+
+  const backgroundClass = isGrayBackgroundPage
+    ? 'bg-custom-gray-50'
+    : 'bg-white';
+
   return (
-    <div className="w-screen h-screen flex flex-col items-center">
+    <div className="w-screen min-h-screen flex flex-col items-center relative">
+      <div className={`absolute inset-0 -z-10 ${backgroundClass}`} />
       <Header />
       <main className="flex-1 w-full max-w-[1000px] px-4">{children}</main>
       <Footer />

--- a/src/shared/components/modal/confirm.tsx
+++ b/src/shared/components/modal/confirm.tsx
@@ -26,11 +26,16 @@ const Confirm: React.FC<ConfirmModalProps> = ({
       height={height}
       justifyContent="justify-end"
     >
-      <div className="w-full flex justify-center" style={{ whiteSpace: 'pre-line' }}>{children}</div>
+      <div
+        className="w-full flex justify-center"
+        style={{ whiteSpace: 'pre-line' }}
+      >
+        {children}
+      </div>
       <div className="mt-11 flex justify-end">
         <button
           onClick={onConfirm}
-          className="px-4 h-12 py-2 bg-custom-gray-800 rounded-xl text-white hover:bg-custom-gray-700"
+          className="px-4 h-12 py-2 bg-custom-gray-800 rounded-xl text-white hover:bg-custom-gray-700 cursor-pointer"
         >
           확인
         </button>

--- a/src/shared/components/modal/confirmCancel.tsx
+++ b/src/shared/components/modal/confirmCancel.tsx
@@ -37,13 +37,13 @@ const ConfirmCancel: React.FC<ConfirmCancelModalProps> = ({
       <div className="flex justify-center space-x-2">
         <button
           onClick={onCancel}
-          className="w-22.5 h-10 bg-white text-custom-gray-800 rounded-xl border border-custom-gray-800 hover:bg-custom-gray-100"
+          className="w-22.5 h-10 bg-white text-custom-gray-800 rounded-xl border border-custom-gray-800 hover:bg-custom-gray-100 cursor-pointer"
         >
           아니오
         </button>
         <button
           onClick={onConfirm}
-          className="w-22.5 h-10 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700"
+          className="w-22.5 h-10 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700 cursor-pointer"
         >
           확인
         </button>

--- a/src/shared/components/modal/modalBase.tsx
+++ b/src/shared/components/modal/modalBase.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 interface ModalProps {
   isOpen: boolean;
@@ -19,7 +20,14 @@ const ModalBase: React.FC<ModalProps> = ({
 }) => {
   if (!isOpen) return null;
 
-  return (
+  // 타입 안전하게 container 설정
+  const container: HTMLElement | null =
+    typeof window !== 'undefined' ? document.body : null;
+
+  // 서버에서는 포털을 안 그리게 early return
+  if (!container) return null;
+
+  return ReactDOM.createPortal(
     <div className="fixed inset-0 flex items-center justify-center z-50">
       {/* 배경 */}
       <div className="fixed inset-0 bg-black opacity-50" onClick={onClose} />
@@ -30,7 +38,8 @@ const ModalBase: React.FC<ModalProps> = ({
       >
         {children}
       </div>
-    </div>
+    </div>,
+    container
   );
 };
 

--- a/src/shared/components/modal/navigate.tsx
+++ b/src/shared/components/modal/navigate.tsx
@@ -46,7 +46,7 @@ const Navigate: React.FC<NavigateModalProps> = ({
       <div className="flex justify-center">
         <button
           onClick={handleNavigate}
-          className="w-38 h-10 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700"
+          className="w-38 h-10 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700 cursor-pointer"
         >
           {text}
         </button>

--- a/src/shared/components/modal/send.tsx
+++ b/src/shared/components/modal/send.tsx
@@ -43,7 +43,10 @@ const SendModal: React.FC<SendModalProps> = ({
     >
       <div className="flex flex-row justify-between">
         <h2 className="text-xl font-bold">{title}</h2>
-        <button onClick={onClose} className="hover:bg-custom-gray-100">
+        <button
+          onClick={onClose}
+          className="hover:bg-custom-gray-100 cursor-pointer"
+        >
           <Image src={close} alt="모달 닫기 이미지"></Image>
         </button>
       </div>
@@ -60,7 +63,7 @@ const SendModal: React.FC<SendModalProps> = ({
       <div className="w-full">
         <button
           onClick={() => onSend(content)}
-          className="w-full h-12 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700"
+          className="w-full h-12 bg-custom-gray-800 text-white rounded-xl hover:bg-custom-gray-700 cursor-pointer"
         >
           전송
         </button>

--- a/src/shared/globals.css
+++ b/src/shared/globals.css
@@ -42,7 +42,6 @@
 @layer base {
   body {
     font-family: 'pretendard', 'quantico';
-    background-color: #f5f5f5;
   }
   .dev-font {
     font-family: 'JetBrains Mono', monospace;

--- a/src/shared/hooks/useMediaQuery.ts
+++ b/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    setMatches(media.matches);
+
+    const listener = () => setMatches(media.matches);
+    media.addEventListener('change', listener);
+
+    return () => media.removeEventListener('change', listener);
+  }, [query]);
+
+  return matches;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,16 @@
     "@eslint/core" "^0.12.0"
     levn "^0.4.1"
 
+"@fontsource/jetbrains-mono@^5.2.5":
+  version "5.2.5"
+  resolved "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.5.tgz"
+  integrity sha512-TPZ9b/uq38RMdrlZZkl0RwN8Ju9JxuqMETrw76pUQFbGtE1QbwQaNsLlnUrACNNBNbd0NZRXiJJSkC8ajPgbew==
+
+"@fontsource/orbitron@^5.2.5":
+  version "5.2.5"
+  resolved "https://registry.npmjs.org/@fontsource/orbitron/-/orbitron-5.2.5.tgz"
+  integrity sha512-e3164ITI9u27irFN4tszwj/OIA9q/TIGKWJ6NUEDvziRO3/9RfnJjioBRyLW6lpslu+oV6US/17bNGlMfZqr5A==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz"
@@ -978,14 +988,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/jsonwebtoken@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz"
-  integrity sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==
-  dependencies:
-    "@types/ms" "*"
-    "@types/node" "*"
-
 "@types/mdast@^4.0.0":
   version "4.0.4"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz"
@@ -1003,7 +1005,7 @@
   resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node@*", "@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^20", "@types/node@>=18":
+"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^20", "@types/node@>=18":
   version "20.17.25"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.17.25.tgz"
   integrity sha512-bT+r2haIlplJUYtlZrEanFHdPIZTeiMeh/fSOEbOOfWf9uTn+lg8g0KU6Q3iMgjd9FLuuMAgfCNSkjUbxL6E3Q==
@@ -1574,11 +1576,6 @@ browserslist@^4.24.0, "browserslist@>= 4.21.0":
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
-buffer-equal-constant-time@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
-  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
-
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
@@ -2022,13 +2019,6 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-ecdsa-sig-formatter@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
-  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
-  dependencies:
-    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.5.73:
   version "1.5.123"
@@ -3436,22 +3426,6 @@ jsonfile@^6.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonwebtoken@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
-  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
-  dependencies:
-    jws "^3.2.2"
-    lodash.includes "^4.3.0"
-    lodash.isboolean "^3.0.3"
-    lodash.isinteger "^4.0.4"
-    lodash.isnumber "^3.0.3"
-    lodash.isplainobject "^4.0.6"
-    lodash.isstring "^4.0.1"
-    lodash.once "^4.0.0"
-    ms "^2.1.1"
-    semver "^7.5.4"
-
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz"
@@ -3466,23 +3440,6 @@ jwt-decode@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
-
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz"
-  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
-  dependencies:
-    buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.11"
-    safe-buffer "^5.0.1"
-
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
-  dependencies:
-    jwa "^1.4.1"
-    safe-buffer "^5.0.1"
 
 keyv@^4.5.4:
   version "4.5.4"
@@ -3589,50 +3546,15 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
   integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
-lodash.includes@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
-  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
-
-lodash.isboolean@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
-  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
   integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
-lodash.isinteger@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
-  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
-
-lodash.isnumber@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
-  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
-  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
-  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.once@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
-  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash@^4.17.21:
   version "4.17.21"
@@ -4782,7 +4704,7 @@ react-docgen@^7.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-"react-dom@^16 || ^17 || ^18 || ^19", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.0.0, react-dom@>=16:
+"react-dom@^16 || ^17 || ^18 || ^19", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.0.0, react-dom@>=16, react-dom@>=18.0.0:
   version "19.0.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz"
   integrity sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==
@@ -4841,6 +4763,11 @@ react-quill-new@^3.4.6:
   dependencies:
     lodash-es "^4.17.21"
     quill "~2.0.2"
+
+react-simple-typewriter@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-5.0.1.tgz"
+  integrity sha512-vA5HkABwJKL/DJ4RshSlY/igdr+FiVY4MLsSQYJX6FZG/f1/VwN4y1i3mPXRyfaswrvI8xii1kOVe1dYtO2Row==
 
 react-syntax-highlighter@^15.6.1:
   version "15.6.1"
@@ -5080,11 +5007,6 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-push-apply@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz"
@@ -5112,7 +5034,7 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
+semver@^7.5.3, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
   version "7.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==


### PR DESCRIPTION
## 📌 개요

- 카드 수정, 페이지 카드 컴포넌트 사용시 개수 수정, 배경색 분기처리

## ✨ 주요 변경 사항

- 카드
 1. 호버시 크기가 더 커지게 애니매이션을 추가했습니다.
 2. 페이지 네이션 거리를 좀 더 줬습니다.

- 모달
 1. 포탈 처리를 하여 자식 컴포넌트에서 그려져도 부모 위에서 그려지게 처리했습니다.

- 배경색
 1. 커스텀 레이아웃으로 인해 적용되는 범위가 정해져있어
    그 상단에 div를 추가하여 그려지게 적용했습니다.

- 챌린지, 나의 챌린지
 1. css로는 스타일 처리가 될뿐 데이터 자체는 수정이 안되기 때문에 아래와 같이 수정했습니다.
  1-1. 커스텀 미디어 쿼리를 만들어 원도우 크기에 따라 개수가 변동 되게 수정했습니다. (useMemo는 데이터 갱신이 안됨)
  1-2. 카드 컴포넌트가 사용되는 페이지에 띄워지는 카드 개수를 모바일 4개 나머지 5개가 뜨도록 수정했습니다.

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 빌드, 스타트 모두 확인 했습니다.

## 🔗 관련 이슈

- 

## 📸 스크린샷

https://github.com/user-attachments/assets/31f83546-1ced-47c5-b16a-2778502c6c2b


