### PR TITLE
toast 수정 

### DIFF
--- a/src/api/Translation/api.ts
+++ b/src/api/Translation/api.ts
@@ -1,6 +1,7 @@
 import { Translation } from '@/types';
 import { customFetch } from '../url';
 import { getQueryString } from '@/lib/utill';
+import { TOAST_ID } from '@/constants';
 
 export interface FetchTranslationParams {
   page?: number;
@@ -34,7 +35,9 @@ export const fetchTranslation = async (
   params?: FetchTranslationParams
 ): Promise<FetchTranslationResponse> => {
   const query = getQueryString({ page: params?.page, limit: params?.limit });
-  const res = await customFetch(`/challenges/${id}/translations${query}`);
+  const res = await customFetch(`/challenges/${id}/translations${query}`, {
+    toastId: TOAST_ID.TRANSLATION,
+  });
   return res.json();
 };
 
@@ -43,7 +46,8 @@ export const fetchTranslationById = async (
   challengeId: string
 ): Promise<Translation> => {
   const res = await customFetch(
-    `/challenges/${challengeId}/translations/${id}`
+    `/challenges/${challengeId}/translations/${id}`,
+    { toastId: TOAST_ID.TRANSLATION }
   );
   return res.json();
 };
@@ -58,6 +62,7 @@ export const createTranslation = async (
       method: 'POST',
       body: JSON.stringify({ title: data.title, content: data.content }),
       headers: { 'Content-Type': 'application/json' },
+      toastId: TOAST_ID.TRANSLATION,
     }
   );
   return response.json();
@@ -74,6 +79,7 @@ export const patchTranslation = async (
       method: 'PATCH',
       body: JSON.stringify({ title: data.title, content: data.content }),
       headers: { 'Content-Type': 'application/json' },
+      toastId: TOAST_ID.TRANSLATION,
     }
   );
   return res.json();
@@ -88,12 +94,15 @@ export const createDraft = async (
     method: 'POST',
     body: JSON.stringify({ title, content }),
     headers: { 'Content-Type': 'application/json' },
+    toastId: TOAST_ID.TRANSLATION,
   });
   return res.json();
 };
 
 export const getDraftTranslation = async (id: string): Promise<Translation> => {
-  const response = await customFetch(`/challenges/${id}/drafts`);
+  const response = await customFetch(`/challenges/${id}/drafts`, {
+    toastId: TOAST_ID.TRANSLATION,
+  });
   const data = await response.json();
   return data.data;
 };

--- a/src/api/Translation/hook.ts
+++ b/src/api/Translation/hook.ts
@@ -13,6 +13,7 @@ import {
 import { Translation } from '@/types';
 import { useQueries } from '@tanstack/react-query';
 import { useToastMutation } from '@/shared/hooks/useToastMutation';
+import { TOAST_ID } from '@/constants';
 
 export const useGetTranslationList = (
   id: string,
@@ -21,8 +22,9 @@ export const useGetTranslationList = (
   return useToastQuery<FetchTranslationResponse, unknown>(
     ['translationList', id, params?.page, params?.limit],
     () => fetchTranslation(id, params),
-    'TranslationList-toast',
+    TOAST_ID.TRANSLATION,
     {},
+    false,
     { enabled: !!id }
   );
 };
@@ -31,8 +33,9 @@ export const useGetTranslation = (id: string, challengeId: string) => {
   return useToastQuery<Translation, unknown>(
     ['translation', id, challengeId],
     () => fetchTranslationById(id, challengeId),
-    'Translation-toast',
+    TOAST_ID.TRANSLATION,
     {},
+    false,
     { enabled: !!id && !!challengeId }
   );
 };
@@ -40,8 +43,9 @@ export const useGetDraftTranslation = (id: string) => {
   return useToastQuery<Translation, unknown>(
     ['getDraftTranslation', id],
     () => getDraftTranslation(id),
-    'getDraftTranslation-toast',
+    TOAST_ID.TRANSLATION,
     {},
+    false,
     { enabled: !!id }
   );
 };
@@ -115,7 +119,7 @@ export const useCreateDraft = (id: string) => {
     {
       onSuccess: () => {},
     },
-    'save-translation', // <- toastId (중복 방지용 고유 id)
+    TOAST_ID.TRANSLATION, // <- toastId (중복 방지용 고유 id)
     '임시저장 실패! 😢'
   );
 };

--- a/src/api/auth/AuthApi.ts
+++ b/src/api/auth/AuthApi.ts
@@ -1,3 +1,4 @@
+import { TOAST_ID } from '@/constants';
 import { customFetch } from '../url';
 import { SetUser } from './AuthStore';
 
@@ -27,6 +28,7 @@ export const loginFn = async (
     headers: {
       'Content-Type': 'application/json',
     },
+    toastId: TOAST_ID.AUTH,
   });
   return res.json();
 };
@@ -40,16 +42,20 @@ export const signupFn = async (
     headers: {
       'Content-Type': 'application/json',
     },
+    toastId: TOAST_ID.AUTH,
   });
   return res.json();
 };
 
-export const logoutFn = async (): Promise<void> => {
+export const logoutFn = async (options?: {
+  disableToast?: boolean;
+}): Promise<void> => {
   await customFetch('/auth/logout', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: null,
+    ...options,
   });
 };

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -1,10 +1,10 @@
 import { useRouter } from 'next/navigation';
 import { useToastMutation } from '@/shared/hooks/useToastMutation';
-import toast from 'react-hot-toast';
 import { loginFn, signupFn, logoutFn } from './AuthApi';
 import { useAuthStore } from './AuthStore';
-import { PATH } from '@/constants';
+import { PATH, TOAST_ID } from '@/constants';
 import { flushSync } from 'react-dom';
+import { showToast } from '@/lib/utill';
 
 export const useLogin = () => {
   const { setAuth } = useAuthStore();
@@ -32,7 +32,7 @@ export const useLogin = () => {
         return true;
       },
     },
-    'login-toast'
+    TOAST_ID.AUTH
   );
 };
 
@@ -42,13 +42,12 @@ export const useLogout = () => {
 
   return async () => {
     try {
-      await logoutFn();
+      await logoutFn({ disableToast: true });
       clearAuth();
       document.cookie =
         'accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-      toast.success('로그아웃 되었습니다!');
       setTimeout(() => {
-        router.replace('/auth/login');
+        router.replace('/auth/login?message=logoutSuccess');
       }, 0);
     } catch (err) {
       console.error('❌ 로그아웃 요청 실패:', err);
@@ -74,6 +73,6 @@ export const useSignup = () => {
         return true;
       },
     },
-    'signup-toast'
+    TOAST_ID.AUTH
   );
 };

--- a/src/api/auth/AuthHook.ts
+++ b/src/api/auth/AuthHook.ts
@@ -4,7 +4,6 @@ import { loginFn, signupFn, logoutFn } from './AuthApi';
 import { useAuthStore } from './AuthStore';
 import { PATH, TOAST_ID } from '@/constants';
 import { flushSync } from 'react-dom';
-import { showToast } from '@/lib/utill';
 
 export const useLogin = () => {
   const { setAuth } = useAuthStore();

--- a/src/api/challenge/ChallengeApi.ts
+++ b/src/api/challenge/ChallengeApi.ts
@@ -1,4 +1,5 @@
 import { customFetch } from '@/api/url';
+import { TOAST_ID } from '@/constants';
 import { Challenge, ChallengeUser, DocumentType, FieldType } from '@/types';
 
 export interface FetchChallengeParams {
@@ -57,7 +58,9 @@ const buildQuery = (params: FetchChallengeParams): string => {
 export const fetchChallenges = async (
   params: FetchChallengeParams
 ): Promise<FetchChallengeResponse> => {
-  const res = await customFetch(`/challenges${buildQuery(params)}`);
+  const res = await customFetch(`/challenges${buildQuery(params)}`, {
+    toastId: TOAST_ID.MAIN_CHALLENGE,
+  });
   return res.json();
 };
 
@@ -65,7 +68,8 @@ export const fetchChallengeByParticipating = async (
   params: FetchChallengeParams
 ): Promise<FetchChallengeResponse> => {
   const res = await customFetch(
-    `/challenges/participating${buildQuery(params)}`
+    `/challenges/participating${buildQuery(params)}`,
+    { toastId: TOAST_ID.MAIN_CHALLENGE }
   );
   return res.json();
 };
@@ -73,19 +77,25 @@ export const fetchChallengeByParticipating = async (
 export const fetchChallengeByUser = async (
   params: FetchChallengeParams
 ): Promise<FetchChallengeResponse> => {
-  const res = await customFetch(`/challenges/user${buildQuery(params)}`);
+  const res = await customFetch(`/challenges/user${buildQuery(params)}`, {
+    toastId: TOAST_ID.MAIN_CHALLENGE,
+  });
   return res.json();
 };
 
 export const fetchChallengeByAdmin = async (
   params: FetchChallengeParams
 ): Promise<FetchChallengeResponse> => {
-  const res = await customFetch(`/challenges/manage${buildQuery(params)}`);
+  const res = await customFetch(`/challenges/manage${buildQuery(params)}`, {
+    toastId: TOAST_ID.MAIN_CHALLENGE,
+  });
   return res.json();
 };
 
 export const fetchChallengeById = async (id: string): Promise<Challenge> => {
-  const res = await customFetch(`/challenges/${id}`);
+  const res = await customFetch(`/challenges/${id}`, {
+    toastId: TOAST_ID.MAIN_CHALLENGE,
+  });
   const data = await res.json();
   return data.challenge;
 };
@@ -95,6 +105,7 @@ export const createChallenge = async (data: ChallengeFormRequest) => {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
   return res.json();
 };
@@ -104,6 +115,7 @@ export const editChallenge = async (id: string, data: ChallengeFormRequest) => {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
   return res.json();
 };
@@ -116,6 +128,7 @@ export const editChallengeByAdmin = async (
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
   return res.json();
 };
@@ -123,6 +136,7 @@ export const editChallengeByAdmin = async (
 export const deleteChallenge = async (id: string) => {
   const res = await customFetch(`/challenges/${id}/remove`, {
     method: 'PATCH',
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
   return res.json();
 };
@@ -134,12 +148,15 @@ export const deleteChallengeByAdmin = async (id: string, reason: string) => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ deletedReason: reason }),
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
   return res.json();
 };
 
 export const fetchMyChallenge = async (id: string): Promise<ChallengeUser> => {
-  const res = await customFetch(`/challenges/${id}`);
+  const res = await customFetch(`/challenges/${id}`, {
+    toastId: TOAST_ID.MAIN_CHALLENGE,
+  });
   return res.json();
 };
 
@@ -151,11 +168,13 @@ export const rejectChallenge = async (
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ rejectedReason: reason }),
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
 };
 
 export const approveChallenge = async (id: string): Promise<void> => {
   await customFetch(`/challenges/${id}/admin/approve`, {
     method: 'PATCH',
+    toastId: TOAST_ID.MAIN_CHALLENGE,
   });
 };

--- a/src/api/challenge/ChallengeHooks.ts
+++ b/src/api/challenge/ChallengeHooks.ts
@@ -14,13 +14,15 @@ import {
   deleteChallengeByAdmin,
 } from './ChallengeApi';
 import { useQueryClient } from '@tanstack/react-query';
+import { TOAST_ID } from '@/constants';
 
 export const useGetChallenge = (id: string) => {
   return useToastQuery<Challenge, Challenge>(
     ['challenge', id],
     () => fetchChallengeById(id),
-    'challenge-toast',
+    TOAST_ID.MAIN_CHALLENGE,
     {},
+    false,
     { enabled: !!id }
   );
 };
@@ -29,8 +31,9 @@ export const useGetMyChallenge = (id: string) => {
   return useToastQuery<ChallengeUser, unknown>(
     ['my-challenge', id],
     () => fetchMyChallenge(id),
-    'challenge-toast',
+    TOAST_ID.MAIN_CHALLENGE,
     {},
+    false,
     { enabled: !!id }
   );
 };
@@ -51,7 +54,7 @@ export const useCreateChallenge = () => {
         }, 1500);
       },
     },
-    'challenge-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 };
 
@@ -73,7 +76,7 @@ export const useEditChallenge = (id: string) => {
         }, 1500);
       },
     },
-    'challenge-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 };
 
@@ -92,7 +95,7 @@ export const useChallengeStatusMutation = (id: string) => {
     {
       onSuccess,
     },
-    'approveChallenge-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 
   const rejectMutation = useToastMutation<string, void>(
@@ -103,7 +106,7 @@ export const useChallengeStatusMutation = (id: string) => {
     {
       onSuccess,
     },
-    'rejectChallenge-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 
   return { approveMutation, rejectMutation };
@@ -124,7 +127,7 @@ export const useDeleteChallenge = (id: string) => {
     {
       onSuccess,
     },
-    'deleteChallenge-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 
   return { deleteMutation };
@@ -146,7 +149,7 @@ export const useDeleteChallengeByAdmin = () => {
     {
       onSuccess,
     },
-    'deleteChallengeByAdmin-toast'
+    TOAST_ID.MAIN_CHALLENGE
   );
 
   return { deleteMutation };

--- a/src/api/feedback/api.ts
+++ b/src/api/feedback/api.ts
@@ -1,5 +1,6 @@
 import { Feedback } from '@/types';
 import { customFetch } from '../url';
+import { TOAST_ID } from '@/constants';
 
 export interface FetchFeedBackResponse {
   feedbacks: Feedback[];
@@ -22,6 +23,7 @@ export const fetchFeedBack = async (
 ): Promise<FetchFeedBackResponse> => {
   const res = await customFetch(`/translations/${id}/feedbacks`, {
     method: 'GET',
+    toastId: TOAST_ID.TRANSLATION,
   });
   return res.json();
 };
@@ -36,6 +38,7 @@ export const createFeedBack = async (
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ content }),
+    toastId: TOAST_ID.TRANSLATION,
   });
   return res.json();
 };
@@ -53,6 +56,7 @@ export const patchFeedBack = async (
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ content }),
+      toastId: TOAST_ID.TRANSLATION,
     }
   );
   return res.json();
@@ -61,11 +65,12 @@ export const patchFeedBack = async (
 export const deleteFeedBack = async (
   translationId: string,
   feedBackId: string
-): Promise<FetchFeedBackResponse> => {  
+): Promise<FetchFeedBackResponse> => {
   const res = await customFetch(
     `/translations/${translationId}/feedbacks/${feedBackId}`,
     {
       method: 'DELETE',
+      toastId: TOAST_ID.TRANSLATION,
     }
   );
   return res.json();

--- a/src/api/feedback/hook.ts
+++ b/src/api/feedback/hook.ts
@@ -10,13 +10,15 @@ import {
 } from './api';
 import { useToastMutation } from '@/shared/hooks/useToastMutation';
 import { useQueryClient } from '@tanstack/react-query';
+import { TOAST_ID } from '@/constants';
 
 export const useGetFeedBackList = (id: string) => {
   return useToastQuery<FetchFeedBackResponse, unknown>(
     ['FeedBackList', id],
     () => fetchFeedBack(id),
-    'FeedBackList-toast',
+    TOAST_ID.TRANSLATION,
     {},
+    false,
     { enabled: !!id }
   );
 };
@@ -33,7 +35,7 @@ export const useCreateFeedBack = (id: string) => {
         queryClient.invalidateQueries({ queryKey: ['FeedBackList', id] });
       },
     },
-    'createFeedback-toast'
+    TOAST_ID.TRANSLATION
   );
 };
 
@@ -52,7 +54,7 @@ export const usePatchFeedBack = (translationId: string) => {
         });
       },
     },
-    'patchFeedback-toast'
+    TOAST_ID.TRANSLATION
   );
 };
 
@@ -70,6 +72,6 @@ export const useDeleteFeedBack = (translationId: string) => {
         });
       },
     },
-    'deleteFeedback-toast'
+    TOAST_ID.TRANSLATION
   );
 };

--- a/src/api/like/api.ts
+++ b/src/api/like/api.ts
@@ -1,3 +1,4 @@
+import { TOAST_ID } from '@/constants';
 import { customFetch } from '../url';
 
 export interface LikeRequest {
@@ -16,6 +17,7 @@ export const createLike = async (id: string): Promise<CreateLikeResponse> => {
     headers: {
       'Content-Type': 'application/json',
     },
+    toastId: TOAST_ID.TRANSLATION,
   });
   return res.json();
 };
@@ -26,6 +28,7 @@ export const deleteLike = async (id: string): Promise<CreateLikeResponse> => {
     headers: {
       'Content-Type': 'application/json',
     },
+    toastId: TOAST_ID.TRANSLATION,
   });
   return res.json();
 };

--- a/src/api/like/hook.ts
+++ b/src/api/like/hook.ts
@@ -1,6 +1,7 @@
 import { useToastMutation } from '@/shared/hooks/useToastMutation';
 import { createLike, deleteLike, LikeRequest } from './api';
 import { useQueryClient } from '@tanstack/react-query';
+import { TOAST_ID } from '@/constants';
 
 export const useCreateLike = (id: string) => {
   const queryClient = useQueryClient();
@@ -15,7 +16,7 @@ export const useCreateLike = (id: string) => {
       },
     },
 
-    'createLike-toast'
+    TOAST_ID.TRANSLATION
   );
 };
 export const useDeleteLike = (id: string) => {
@@ -31,6 +32,6 @@ export const useDeleteLike = (id: string) => {
       },
     },
 
-    'deleteLike-toast'
+    TOAST_ID.TRANSLATION
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,15 +25,15 @@ export default function RootLayout({
       <body>
         <ToastProvider />
         <ReactQueryProvider>
-          <AuthProvider>
-            <Suspense fallback={<div>로딩 중...</div>}>
+          <Suspense fallback={<div>로딩 중...</div>}>
+            <AuthProvider>
               {isAuthPage || isLandingPage ? (
                 <>{children}</>
               ) : (
                 <Layout>{children}</Layout>
               )}
-            </Suspense>
-          </AuthProvider>
+            </AuthProvider>
+          </Suspense>
         </ReactQueryProvider>
       </body>
     </html>

--- a/src/app/main/challenge/_components/ChallengeMain.tsx
+++ b/src/app/main/challenge/_components/ChallengeMain.tsx
@@ -10,7 +10,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import CardSkeleton from '@/shared/components/card/CardSkeleton';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
 import { useDeleteChallengeByAdmin } from '@/api/challenge/ChallengeHooks';
-import { PATH } from '@/constants';
+import { PATH, TOAST_ID } from '@/constants';
 
 const ChallengeMain = () => {
   const [keyword, setKeyword] = useState('');
@@ -39,11 +39,12 @@ const ChallengeMain = () => {
         fields: filters.fields,
         status: filters.status,
       }),
-    'challenge-toast',
+    TOAST_ID.MAIN_CHALLENGE,
     {
       pending: '불러오는 중...',
       success: '불러오기 완료!',
     },
+    false,
     {
       keepPreviousData: true,
     }

--- a/src/app/main/challenge/new/page.tsx
+++ b/src/app/main/challenge/new/page.tsx
@@ -8,7 +8,6 @@ import { DocumentType, FieldType } from '@/types';
 import { NextPage } from 'next';
 import { useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import toast from 'react-hot-toast';
 
 const NewChallenge: NextPage = () => {
   const methods = useForm();
@@ -27,12 +26,6 @@ const NewChallenge: NextPage = () => {
     try {
       await mutateAsync(formattedData);
     } catch {
-      toast.error('입력 오류입니다.', {
-        style: {
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-        },
-      });
       setIsProcessing(false);
     }
   };

--- a/src/app/main/my-challenge/components/MyChallengeMain.tsx
+++ b/src/app/main/my-challenge/components/MyChallengeMain.tsx
@@ -18,6 +18,7 @@ import { useSearchParams } from 'next/navigation';
 import CardSkeleton from '@/shared/components/card/CardSkeleton';
 import ChallengeTable from './ChallengeTable';
 import { useMediaQuery } from '@/shared/hooks/useMediaQuery';
+import { TOAST_ID } from '@/constants';
 
 const TAB_LIST = [
   { key: 'participating', label: '참여중인 챌린지' },
@@ -88,11 +89,12 @@ const MyChallengeMain = () => {
               : undefined,
       });
     },
-    'challenge-toast',
+    TOAST_ID.MAIN_CHALLENGE,
     {
       pending: '불러오는 중...',
       success: '불러오기 완료!',
     },
+    false,
     {
       keepPreviousData: true,
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,18 @@ export const PATH = {
   translation: '/main/translation',
   admin: '/admin/challenges',
 };
+
+export const TOAST_ID = {
+  AUTH: 'auth-toast',
+  MAIN_CHALLENGE: 'main-challenge-toast',
+  MY_CHALLENGE: 'my-challenge-toast',
+  TRANSLATION: 'translation-toast',
+  TRANSLATION_WORK: 'translation-work-toast',
+  NOTIFICATION: 'notification',
+  ADMIN: 'admin-toast',
+  LIKE: 'like',
+  MODAL: 'modal-toast',
+  SERVER: 'server',
+} as const;
+
+export type ToastId = (typeof TOAST_ID)[keyof typeof TOAST_ID];

--- a/src/core/provider/AuthProvider.tsx
+++ b/src/core/provider/AuthProvider.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { AuthState, useAuthStore, useHydrated } from '@/api/auth/AuthStore';
-import { PATH } from '@/constants';
+import { PATH, TOAST_ID } from '@/constants';
+import { showToast } from '@/lib/utill';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { createContext, useContext, useEffect } from 'react';
-import toast from 'react-hot-toast';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 const publicPaths = ['/', PATH.login, PATH.signup, PATH.challenge];
 const homePaths = ['/'];
@@ -20,6 +20,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [handledMessage, setHandledMessage] = useState<string | null>(null);
   const { user, setAuth, clearAuth } = useAuthStore();
   const router = useRouter();
   const pathname = usePathname();
@@ -40,15 +41,33 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const isAdminPage = pathname.startsWith('/admin');
 
     const message = searchParams.get('message');
+
+    if (!message) return;
+
+    const cleanedUrl = `${window.location.pathname}${window.location.hash}`;
+    router.replace(cleanedUrl);
+    setHandledMessage(message);
+
     if (message) {
       if (message === 'needLogin') {
-        toast.error('로그인이 필요합니다.');
+        showToast({
+          type: 'error',
+          message: '로그인이 필요합니다.',
+          id: TOAST_ID.AUTH,
+        });
       } else if (message === 'adminOnly') {
-        toast.error('관리자 권한이 필요합니다.');
+        showToast({
+          type: 'error',
+          message: '관리자 권한이 필요합니다.',
+          id: TOAST_ID.AUTH,
+        });
+      } else if (message === 'logoutSuccess') {
+        showToast({
+          type: 'error',
+          message: '로그아웃 되었습니다!',
+          id: TOAST_ID.AUTH,
+        });
       }
-
-      const cleanedUrl = `${window.location.pathname}${window.location.hash}`;
-      router.replace(cleanedUrl);
     }
 
     if (!isLoggedIn && !isPublic) {
@@ -71,6 +90,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     isHome,
     searchParams,
     user?.role,
+    handledMessage,
   ]);
 
   if (!hydrated) {

--- a/src/lib/utill.ts
+++ b/src/lib/utill.ts
@@ -4,6 +4,8 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import localeData from 'dayjs/plugin/localeData';
 import 'dayjs/locale/ko';
+import toast from 'react-hot-toast';
+import { ToastId } from '@/constants';
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -38,4 +40,40 @@ export const getQueryString = (
 
   const query = new URLSearchParams(stringParams).toString();
   return query ? `?${query}` : '';
+};
+
+type ToastType = 'loading' | 'success' | 'error';
+
+interface ShowToastOptions {
+  type: ToastType;
+  message: string;
+  id?: ToastId;
+  disableToast?: boolean;
+}
+
+export const showToast = ({
+  type,
+  message,
+  id,
+  disableToast = false,
+}: ShowToastOptions) => {
+  if (disableToast) return;
+
+  if (id) {
+    toast.dismiss(id); // 기존 같은 ID 토스트 닫기 (중복 방지)
+  }
+
+  const options = id ? { id, duration: 1000 } : { duration: 1000 };
+
+  switch (type) {
+    case 'loading':
+      toast.loading(message, options);
+      break;
+    case 'success':
+      toast.success(message, options);
+      break;
+    case 'error':
+      toast.error(message, options);
+      break;
+  }
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,7 @@ async function verifyToken(token: string): Promise<JwtPayload | null> {
     const { payload } = await jwtVerify<JwtPayload>(token, secret);
     return payload;
   } catch (error) {
+    console.error('[JWT Verify Error]', error);
     return null;
   }
 }

--- a/src/shared/components/input/search.tsx
+++ b/src/shared/components/input/search.tsx
@@ -33,14 +33,14 @@ const Search: FC<SearchInputProps> = ({
   };
 
   return (
-    <div className="relative bg-white">
+    <div className="relative ">
       <input
         type="search"
         name={name}
         value={value}
         onChange={handleChange}
         placeholder={placeholder}
-        className={`pl-9 rounded-3xl pr-4 py-2 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-custom-gray-300 ${size}`}
+        className={`pl-9 rounded-3xl pr-4 py-2 bg-white border border-gray-300 focus:outline-none focus:ring-2 focus:ring-custom-gray-300 ${size}`}
         onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
       />
       <button

--- a/src/shared/hooks/useToastMutation.ts
+++ b/src/shared/hooks/useToastMutation.ts
@@ -1,3 +1,5 @@
+import { ToastId } from '@/constants';
+import { showToast } from '@/lib/utill';
 import {
   useMutation,
   UseMutationOptions,
@@ -21,28 +23,35 @@ export function useToastMutation<
   mutationFn: (variables: TVariables) => Promise<TData>,
   toastMessages?: ToastMessages,
   options?: UseMutationOptions<TData, TError, TVariables, TContext>,
-  toastId?: string,
-  handledMessage?: string
+  toastId?: ToastId,
+  handledMessage?: string,
+  disableToast: boolean = false
 ): UseMutationResult<TData, TError, TVariables, TContext> {
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn,
     ...options,
     onMutate: async (variables) => {
       if (toastId) toast.dismiss(toastId);
-      if (toastMessages?.pending)
-        toast.loading(toastMessages.pending, {
+      if (toastMessages?.pending) {
+        showToast({
+          type: 'loading',
+          message: toastMessages.pending,
           id: toastId,
-          duration: 3000,
+          disableToast,
         });
+      }
       return options?.onMutate?.(variables);
     },
     onSuccess: (data, variables, context) => {
       if (toastId) toast.dismiss(toastId);
-      if (toastMessages?.success)
-        toast.success(toastMessages.success, {
+      if (toastMessages?.success) {
+        showToast({
+          type: 'success',
+          message: toastMessages.success,
           id: toastId,
-          duration: 3000,
+          disableToast,
         });
+      }
       options?.onSuccess?.(data, variables, context);
     },
     onError: (error, variables, context) => {
@@ -60,9 +69,11 @@ export function useToastMutation<
         serverErrorMessage = error.message;
       }
 
-      toast.error(serverErrorMessage, {
+      showToast({
+        type: 'error',
+        message: serverErrorMessage,
         id: toastId,
-        duration: 3000,
+        disableToast,
       });
       options?.onError?.(error, variables, context);
     },

--- a/src/shared/hooks/useToastQuery.ts
+++ b/src/shared/hooks/useToastQuery.ts
@@ -1,3 +1,5 @@
+import { ToastId } from '@/constants';
+import { showToast } from '@/lib/utill';
 import {
   useQuery,
   UseQueryOptions,
@@ -40,8 +42,9 @@ export function useToastQuery<
 >(
   queryKey: TQueryKey,
   queryFn: () => Promise<TQueryFnData>,
-  toastId?: string,
+  toastId?: ToastId,
   toastMessages?: ToastMessages,
+  disableToast: boolean = false,
   options: ToastQueryOptions<TQueryFnData, TError, TData, TQueryKey> = {}
 ): UseQueryResult<TData, TError> {
   const {
@@ -59,7 +62,14 @@ export function useToastQuery<
       ...restOptions,
       onSuccess: (data: TData) => {
         if (toastId) toast.dismiss(toastId);
-        if (toastMessages?.success) toast.success(toastMessages.success);
+        if (toastMessages?.success) {
+          showToast({
+            type: 'success',
+            message: toastMessages.success,
+            id: toastId,
+            disableToast,
+          });
+        }
         userOnSuccess?.(data);
       },
       onError: (error: TError, variables: TQueryKey, context: unknown) => {
@@ -70,7 +80,12 @@ export function useToastQuery<
           serverErrorMessage = error.message;
         }
 
-        toast.error(serverErrorMessage);
+        showToast({
+          type: 'error',
+          message: serverErrorMessage,
+          id: toastId,
+          disableToast,
+        });
         userOnError?.(error, variables, context);
       },
       onSettled: (

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://docthru-be-wstf.onrender.com/api/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 개요

- TOAST 아이디 통일(중복 생성 방지)
- disableToast 추가 (기본 false = 토스트 생성 X, true = 토스트 생성 O)

## ✨ 주요 변경 사항

- constants.ts에 TOAST_ID 추가
 1. PATH와 같이 TOAST_ID 통일

- showToast 커스텀 함수 showToasty(type, message, id?, disableToast?)  - lib/utill.ts
 1. type : loading, success, error 중 하나 선택 사용
 2. message: 사용한 메세지
 3. id: 토스트 고유 아이디
 4. disableToast :  false = 생성 O, true = 생성 X
 5. 기본 1초 지속

- useToastMutation, useToastQuery
 1. disableToast 추가
 2. 토스트함수 부분 showToast 로 변경

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 기존에 있던 api아래 Api, hook 모두 toastId부분은 전부 수정했습니다. 
   참고하시고 사용하시면 됩니다.

## 🔗 관련 이슈

- 

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
