### PR TITLE
142 bug fix

### DIFF
--- a/src/api/Translation/api.ts
+++ b/src/api/Translation/api.ts
@@ -87,6 +87,17 @@ export const patchTranslation = async (
   return res.json();
 };
 
+export const deleteTranslation = async (
+  id: string,
+  challengeId: string
+): Promise<Translation> => {
+  const res = await customFetch(
+    `/challenges/${challengeId}/translations/${id}`,
+    { method: 'DELETE' }
+  );
+  return res.json();
+};
+
 export const createDraft = async (
   id: string,
   title: string,

--- a/src/api/Translation/hook.ts
+++ b/src/api/Translation/hook.ts
@@ -1,6 +1,7 @@
 import { useToastQuery } from '@/shared/hooks/useToastQuery';
 import {
   createDraft,
+  deleteTranslation,
   DraftRequest,
   DraftResponse,
   fetchTranslation,
@@ -8,7 +9,6 @@ import {
   FetchTranslationParams,
   FetchTranslationResponse,
   getDraftTranslation,
-  // patchTranslation,
 } from './api';
 import { Translation } from '@/types';
 import { useQueries } from '@tanstack/react-query';
@@ -26,6 +26,19 @@ export const useGetTranslationList = (
     {},
     false,
     { enabled: !!id }
+  );
+};
+export const useGetTranslationListAll = (
+  id: string,
+  totalCount: number,
+  params: FetchTranslationParams
+) => {
+  return useToastQuery<FetchTranslationResponse, unknown>(
+    ['translationList', id, params?.page, params?.limit],
+    () => fetchTranslation(id, params),
+    'TranslationList-toast',
+    {},
+    { enabled: !!id && !!totalCount }
   );
 };
 
@@ -47,6 +60,30 @@ export const useGetDraftTranslation = (id: string) => {
     {},
     false,
     { enabled: !!id }
+  );
+};
+
+interface DeleteTranslationArgs {
+  challengeId: string;
+  translationId: string;
+}
+
+export const useDeleteTranslation = () => {
+  return useToastMutation<DeleteTranslationArgs>(
+    ({ challengeId, translationId }) =>
+      deleteTranslation(translationId, challengeId),
+    {
+      pending: '번역물 삭제 중입니다...',
+      success: '번역물 삭제 완료!',
+    },
+    {
+      onSuccess: () => {},
+      onError: (error) => {
+        // 여기에 원하는 에러 처리 로직 작성
+        console.error(error);
+      },
+    },
+    'deleteTranslation-toast'
   );
 };
 

--- a/src/api/Translation/hook.ts
+++ b/src/api/Translation/hook.ts
@@ -34,11 +34,11 @@ export const useGetTranslationListAll = (
   params: FetchTranslationParams
 ) => {
   return useToastQuery<FetchTranslationResponse, unknown>(
-    ['translationList', id, params?.page, params?.limit],
+    ['translationListAll', id, params?.page, params?.limit],
     () => fetchTranslation(id, params),
-    'TranslationList-toast',
+    TOAST_ID.TRANSLATION,
     {},
-    { enabled: !!id && !!totalCount }
+    !!id && !!totalCount
   );
 };
 
@@ -83,7 +83,7 @@ export const useDeleteTranslation = () => {
         console.error(error);
       },
     },
-    'deleteTranslation-toast'
+    TOAST_ID.TRANSLATION
   );
 };
 

--- a/src/api/challenge/ChallengeHooks.ts
+++ b/src/api/challenge/ChallengeHooks.ts
@@ -116,6 +116,7 @@ export const useDeleteChallenge = (id: string) => {
   const queryClient = useQueryClient();
 
   const onSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: ['challenges'] });
     queryClient.invalidateQueries({ queryKey: ['my-challenge', id] });
   };
 

--- a/src/app/main/challenge/[id]/components/MostRecommend.tsx
+++ b/src/app/main/challenge/[id]/components/MostRecommend.tsx
@@ -16,17 +16,16 @@ interface MostRecommendProps {
 export const MostRecommend: React.FC<MostRecommendProps> = ({ data }) => {
   const [isViewAll, setIsViewAll] = useState(false);
   const [contentHeight, setContentHeight] = useState('0px');
+  const [isOverflow, setIsOverflow] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (contentRef.current) {
-      if (isViewAll) {
-        setContentHeight(`${contentRef.current.scrollHeight}px`);
-      } else {
-        setContentHeight('180px');
-      }
+      const fullHeight = contentRef.current.scrollHeight;
+      setIsOverflow(fullHeight > 180);
+      setContentHeight(isViewAll ? `${fullHeight}px` : '180px');
     }
-  }, [isViewAll]);
+  }, [isViewAll, data]);
   return (
     <div className="flex flex-col w-full h-full  mb-6 bg-custom-gray-50 rounded-2xl border-2 border-custrom-gray-100  ">
       <div className="flex gap-1 w-fit px-4 py-2  bg-custom-gray-800 rounded-tl-2xl rounded-br-2xl M-14-0 text-white">
@@ -65,15 +64,17 @@ export const MostRecommend: React.FC<MostRecommendProps> = ({ data }) => {
           />
         </div>
       </div>
-      <div
-        onClick={() => {
-          setIsViewAll(!isViewAll);
-        }}
-        className="flex justify-center cursor-pointer pt-[6.5px] gap-1 M-16-0"
-      >
-        {isViewAll ? '접기' : '더보기'}
-        <Image src={isViewAll ? up : down} alt="arrow" />
-      </div>
+      {isOverflow && (
+        <div
+          onClick={() => {
+            setIsViewAll(!isViewAll);
+          }}
+          className="flex justify-center cursor-pointer pt-[6.5px] gap-1 M-16-0"
+        >
+          {isViewAll ? '접기' : '더보기'}
+          <Image src={isViewAll ? up : down} alt="arrow" />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/main/challenge/[id]/page.tsx
+++ b/src/app/main/challenge/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'next/navigation';
 import { useGetChallenge } from '@/api/challenge/ChallengeHooks';
 import {
   useGetTranslationList,
+  useGetTranslationListAll,
   useGetTranslationsByIds,
 } from '@/api/Translation/hook';
 import { useAuthStore } from '@/api/auth/AuthStore';
@@ -23,86 +24,79 @@ const ChallengeDetail: NextPage = () => {
   const { user } = useAuthStore();
   const { data: challenge } = useGetChallenge(id);
   const { data: translationList } = useGetTranslationList(id, {
-    page: page,
+    page,
     limit: 5,
   });
+  const totalCount = translationList ? translationList.totalCount : 0;
+  const { data: translationListAll } = useGetTranslationListAll(
+    id,
+    totalCount,
+    {
+      page,
+      limit: totalCount,
+    }
+  );
+
   const slideRef = useRef<HTMLDivElement>(null);
   const [slideWidth, setSlideWidth] = useState(0);
-
   const totalPage = translationList?.totalCount;
   const maxPage = totalPage ? Math.ceil(totalPage / 5) : 0;
-  const handleNextPage = () => {
-    if (page <= maxPage) {
-      setPage(page + 1);
-    }
-  };
-  const handlePrevPage = () => {
-    if (page >= 1) {
-      setPage(page - 1);
-    }
-  };
+
+  const handleNextPage = () => setPage((page) => Math.min(page + 1, maxPage));
+  const handlePrevPage = () => setPage((page) => Math.max(page - 1, 1));
 
   const isSameUser = user?.id === challenge?.userId;
-
-  const mostLikeCount = translationList?.translations[0]?.likeCount;
-
-  const mostRecommendedIds = translationList?.translations
-    ?.filter((t: Translation) => t.likeCount === mostLikeCount)
-    .map((t: Translation) => t.id);
+  const mostRecommendedIds = translationListAll
+    ? translationListAll?.translations.map((t: Translation) => t.id)
+    : translationList
+      ? translationList.translations.map((t: Translation) => t.id)
+      : [];
+  const userTranslation = translationListAll?.translations.find(
+    (translation) => translation.user.id === user?.id
+  );
 
   const { data: mostData } = useGetTranslationsByIds(id, mostRecommendedIds);
-
   const isSingleSlide = mostData?.length === 1;
 
-  const handleNextSlide = () => {
-    if (mostData && slideIndex < mostData.length - 1) {
-      setSlideIndex(slideIndex + 1);
-    }
-  };
-  const handlePrevSlide = () => {
-    if (mostData && slideIndex > 0) {
-      setSlideIndex(slideIndex - 1);
-    }
-  };
+  const handleNextSlide = () =>
+    setSlideIndex((index) => Math.min(index + 1, mostData.length - 1));
+  const handlePrevSlide = () =>
+    setSlideIndex((index) => Math.max(index - 1, 0));
 
   useEffect(() => {
-    if (!mostData || mostData.length === 0) return;
-
-    const raf = requestAnimationFrame(() => {
-      if (slideRef.current) {
-        const width = slideRef.current.offsetWidth + 24;
-        setSlideWidth(width);
-      }
-    });
-
-    return () => cancelAnimationFrame(raf);
+    if (mostData && mostData.length > 0) {
+      const width = slideRef.current ? slideRef.current.offsetWidth + 24 : 0;
+      setSlideWidth(width);
+    }
   }, [mostData]);
 
   return (
-    <div className="flex flex-col gap-6 w-full ">
-      <Title data={challenge} isSameUser={isSameUser} challengeId={id} />
+    <div className="flex flex-col gap-6 w-full">
+      <Title
+        data={challenge}
+        isSameUser={isSameUser}
+        challengeId={id}
+        isUserTranslationPresent={userTranslation}
+      />
 
       <div className="relative overflow-hidden w-full">
         <div
           className="flex transition-transform duration-500 gap-6"
-          style={{
-            transform: `translateX(-${slideIndex * slideWidth}px)`,
-          }}
+          style={{ transform: `translateX(-${slideIndex * slideWidth}px)` }}
         >
           {challenge?.isDeadlineFull &&
-            mostData.map((d, index) => (
+            mostData?.map((d, index) => (
               <div
                 key={index}
                 ref={index === 0 ? slideRef : null}
-                className={`relative min-w-[95%] min-h-[340px] shrink-0 
-                ${isSingleSlide ? 'min-w-full max-w-full' : 'min-w-[95%] max-w-[95%]'}`}
+                className={`relative ${isSingleSlide ? 'min-w-full max-w-full' : 'min-w-[95%] max-w-[95%]'} min-h-[340px] shrink-0`}
               >
                 <MostRecommend data={d} />
               </div>
             ))}
         </div>
 
-        {mostData.length > 1 && slideIndex < mostData.length - 1 && (
+        {mostData?.length > 1 && slideIndex < mostData.length - 1 && (
           <button
             onClick={handleNextSlide}
             className="absolute right-[3%] bottom-[50%] cursor-pointer opacity-30 hover:opacity-100 transition-transform duration-300 ease-in-out hover:-translate-y-1"

--- a/src/app/main/translation-work/_components/PatchMain.tsx
+++ b/src/app/main/translation-work/_components/PatchMain.tsx
@@ -10,13 +10,13 @@ import { fetchChallengeById } from '@/api/challenge/ChallengeApi';
 export default function PatchMain() {
   const [showOriginal, setShowOriginal] = useState(false);
   const searchParams = useSearchParams();
-  const [originUrl, setOriginUrl] = useState("https://nextjs-ko.org/docs");
+  const [originUrl, setOriginUrl] = useState('https://nextjs-ko.org/docs');
   useEffect(() => {
     const cid = searchParams.get('challengeId') as string;
     getChallengeOrigin(cid);
   }, [searchParams]);
 
-  async function getChallengeOrigin (id: string) {
+  async function getChallengeOrigin(id: string) {
     const result = await fetchChallengeById(id);
     setOriginUrl(result.originURL);
   }

--- a/src/app/main/translation/[id]/_components/Title.tsx
+++ b/src/app/main/translation/[id]/_components/Title.tsx
@@ -1,21 +1,59 @@
 import { Chip } from '@/shared/components/chip/chip';
 import { Divider } from '@/shared/components/Divider';
 import { DocumentType, FieldType } from '@/types';
+import menu from '@images/menu-icon/Meatballs.svg';
+import Image from 'next/image';
+import { useState } from 'react';
 
 interface TitleProps {
   title?: string;
   document?: DocumentType;
   field?: FieldType;
+  onModify?: () => void;
+  onDelete?: () => void;
+  isAdmin: boolean;
+  isSameUser: boolean;
 }
 
 export const Title: React.FC<TitleProps> = ({
   title,
   document = '블로그',
   field = 'Next.js',
+  onModify,
+  onDelete,
+  isAdmin,
+  isSameUser,
 }) => {
+  const [openMenu, setOpenMenu] = useState(false);
   return (
     <div className="flex flex-col pt-10 gap-4">
-      <div className="w-full SB-24-0">{title}</div>
+      <div className="w-full flex justify-between  SB-24-0">
+        <div>{title}</div>
+        <div
+          className="relative cursor-pointer"
+          onClick={() => setOpenMenu(!openMenu)}
+        >
+          <Image src={menu} alt="menu" />
+          {isAdmin ||
+            (isSameUser && (
+              <div className="flex flex-col R-16-0 absolute right-0  whitespace-nowrap z-10">
+                <button
+                  className="p-2 bg-white rounded-t-lg shadow-md hover: hover:bg-custom-gray-300 transition-colors duration-150 cursor-pointer"
+                  onClick={onModify}
+                >
+                  수정하기
+                </button>
+                <Divider />
+                <button
+                  className="p-2 bg-white rounded-b-lg shadow-md hover: hover:bg-custom-gray-300 transition-colors duration-150 cursor-pointer"
+                  onClick={onDelete}
+                >
+                  삭제하기
+                </button>
+              </div>
+            ))}
+        </div>
+      </div>
       <div className="flex flex-row gap-2">
         <Chip label={field} />
         <Chip label={document} />

--- a/src/app/main/translation/[id]/_components/modal.tsx
+++ b/src/app/main/translation/[id]/_components/modal.tsx
@@ -1,0 +1,22 @@
+import Button, { ButtonCategory } from '@/shared/components/button/Button';
+
+interface ModalProps {
+  content: string;
+  apply: () => void;
+  cancle: () => void;
+}
+export const Modal: React.FC<ModalProps> = ({ content, apply, cancle }) => {
+  return (
+    <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-5 w-[400px] h-[200px] bg-white border-2 border-custom-gray-300 rounded-2xl shadow-lg z-50">
+      <div className="flex h-[80%] justify-center items-center">{content}</div>
+      <div className="flex justify-between">
+        <Button category={ButtonCategory.CANCEL} onClick={cancle}>
+          취소
+        </Button>
+        <Button category={ButtonCategory.APPLY} onClick={apply}>
+          확인
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/main/translation/[id]/page.tsx
+++ b/src/app/main/translation/[id]/page.tsx
@@ -1,22 +1,41 @@
 'use client';
-import { useParams, useSearchParams } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Title } from './_components/Title';
 import { Author } from './_components/Author';
 import { Content } from './_components/Content';
-import { useGetTranslation } from '@/api/Translation/hook';
+import {
+  useDeleteTranslation,
+  useGetTranslation,
+} from '@/api/Translation/hook';
 import { useGetFeedBackList, useCreateFeedBack } from '@/api/feedback/hook';
 import { FeedBack } from './_components/FeedBack';
 import { useCreateLike, useDeleteLike } from '@/api/like/hook';
+import { useGetChallenge } from '@/api/challenge/ChallengeHooks';
+import { Modal } from './_components/modal';
+import { useState } from 'react';
+import { useAuthStore } from '@/api/auth/AuthStore';
+import { PATH } from '@/constants';
 
 const TranslationDetail: React.FC = () => {
   const searchParams = useSearchParams();
   const { id } = useParams() as { id: string };
   const challengeId = searchParams.get('challengeId') as string;
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalText, setModalText] = useState('');
+  const [isDelete, setIsDelete] = useState(false);
+  const { user } = useAuthStore();
   const { data: translation } = useGetTranslation(id, challengeId as string);
   const { data: feedback } = useGetFeedBackList(id);
   const { mutate: createFeedBack } = useCreateFeedBack(id);
   const { mutate: createLike } = useCreateLike(id);
   const { mutate: deleteLike } = useDeleteLike(id);
+  const { mutate: Delete } = useDeleteTranslation();
+
+  const { data: challenge } = useGetChallenge(translation?.challengeId || '');
+
+  const isSameUser = translation?.user.id === user?.id;
+  const isAdmin = user?.role === 'ADMIN';
 
   const onHandleLike = async () => {
     if (!translation?.isLiked) {
@@ -26,9 +45,67 @@ const TranslationDetail: React.FC = () => {
     }
   };
 
+  const openMdify = () => {
+    if (isAdmin) {
+      setModalText('수정 페이지로 이동합니다.');
+      setIsOpen(true);
+      return;
+    }
+    if (challenge?.isDeadlineFull) {
+      setModalText('마감된 Challenge 수정 할 수 없습니다.');
+      return;
+    }
+    setModalText('수정 페이지로 이동합니다.');
+    setIsOpen(true);
+  };
+
+  const openDelete = () => {
+    if (isAdmin) {
+      setModalText('정말 삭제 하시겠습니까?');
+      setIsOpen(true);
+      setIsDelete(true);
+      return;
+    }
+    if (challenge?.isDeadlineFull) {
+      setModalText('마감된 Challenge 삭제 할 수 없습니다.');
+      setIsOpen(true);
+    } else {
+      setModalText('정말 삭제 하시겠습니까?');
+      setIsDelete(true);
+      setIsOpen(true);
+    }
+  };
+
+  const onCancle = () => {
+    setIsOpen(false);
+    setIsDelete(false);
+  };
+
+  const onModify = () => {
+    router.push(`/main/translation-work/${id}?challengeId=${challengeId}`);
+  };
+
+  const onDelete = () => {
+    if (translation) {
+      Delete({
+        challengeId: translation.challengeId,
+        translationId: translation.id,
+      });
+      router.replace(PATH.challenge + `/` + translation.challengeId);
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-4">
-      <Title title={translation?.title} />
+    <div className="flex flex-col gap-4 ">
+      <Title
+        isAdmin={isAdmin}
+        isSameUser={isSameUser}
+        title={translation?.title}
+        field={challenge?.field}
+        document={challenge?.documentType}
+        onDelete={openDelete}
+        onModify={openMdify}
+      />
       <Author
         user={translation?.user}
         create={translation?.createdAt}
@@ -36,6 +113,13 @@ const TranslationDetail: React.FC = () => {
         like={translation?.isLiked}
         likeClick={onHandleLike}
       />
+      {isOpen && (
+        <Modal
+          apply={isDelete ? onDelete : onModify}
+          cancle={onCancle}
+          content={modalText}
+        />
+      )}
       <Content content={translation?.content} />
       <FeedBack
         id={id}

--- a/src/shared/components/OriginView.tsx
+++ b/src/shared/components/OriginView.tsx
@@ -32,7 +32,7 @@ export const OriginView = ({
         src={originUrl}
         width="100%"
         height="100%"
-        title="원본 보기"
+        title="원문 보기"
         className={`${className}`}
       />
     </div>

--- a/src/shared/components/container/Container.tsx
+++ b/src/shared/components/container/Container.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import dayjs from '@/lib/utill';
 import { ButtonHTMLAttributes } from 'react';
 import Button, { ButtonCategory } from '../button/Button';
+import { Translation } from '@/types';
 
 export interface ContainerProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -12,6 +13,7 @@ export interface ContainerProps
   currentParticipants: number | undefined;
   maxParticipants: number | undefined;
   id: string;
+  isUserTranslationPresent?: Translation;
 }
 
 export const Container = ({
@@ -20,6 +22,7 @@ export const Container = ({
   currentParticipants,
   maxParticipants,
   id,
+  isUserTranslationPresent,
   ...props
 }: ContainerProps) => {
   const overDeadLine = dayjs(deadLine).isBefore(dayjs());
@@ -45,7 +48,7 @@ export const Container = ({
             size="text-center py-2"
             href={originUrl}
           >
-            원본 보기
+            원문 보기
           </Button>
         </div>
         <div className="flex w-40 md:w-56 xl:w-60">
@@ -57,6 +60,14 @@ export const Container = ({
               {...props}
             >
               작업 도전하기
+            </Button>
+          ) : !!isUserTranslationPresent ? (
+            <Button
+              category={ButtonCategory.TO_DO_WORK}
+              size="text-center py-3"
+              href={`/main/translation-work/${isUserTranslationPresent.id}?challengeId=${id}`}
+            >
+              작업 이어하기
             </Button>
           ) : (
             <Button


### PR DESCRIPTION
## 📌 개요

- <!-- 이 PR의 내용을 간략하게 설명해주세요 ex) OO페이지 OO기능 추가 -->
작업물 수정 버튼이 없습니다.

어드민, 번역물 작성자가 번역물 수정, 삭제 기능

챌린지 상세 페이지 원본 보기 X → 원문 보기

작업물 수정 후 상세페이지 갔을 때 translation 조회 안되는 현상

my-challenge 목록에서 상세보기 라우팅 시 ‘도전 계속하기’

챌린지 상세, 수정 삭제가 되지 않음. 디자인도 상이

chip 이 API → Next.js로 바뀌는 버그
## ✨ 주요 변경 사항

- <!-- 주요 변경 사항에 대해서 설명해주세요 ex) OO컴포넌트 추가되었습니다., 비밀번호 검증 로직 구현, 반응형 레이아웃 적용 등 -->

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- <!-- ex) 변경 사항을 테스트하는 방법 -->

## 🔗 관련 이슈

- <!-- 관련된 이슈 번호(#000) 혹은 이슈에 대한 설명을 적어주세요 -->

## 📸 스크린샷

- <!-- 필요한 경우 스크린샷을 첨부해주세요 -->
