### PR TITLE
카드 버튼 수정, 챌린지 생성/수정시 수정, 파비콘 추가

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="21" viewBox="0 0 18 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.398438" y="0.374939" width="17.55" height="20.25" rx="1.35" fill="#262626"/>
+<path d="M11.5359 7.12494L13.8984 10.0781L11.5359 13.0312" stroke="#FFC117" stroke-width="1.62"/>
+<path d="M6.81172 7.12494L4.44922 10.0781L6.81172 13.0312" stroke="#FFC117" stroke-width="1.62"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import ClientLayout from './_components/ClientLayout';
 export const metadata = {
   title: '독스루',
   description: '번역 홈페이지',
+  icons: {
+    icon: '/favicon.svg',
+  },
 };
 
 export default function RootLayout({

--- a/src/app/main/my-challenge/components/MyChallengeMain.tsx
+++ b/src/app/main/my-challenge/components/MyChallengeMain.tsx
@@ -247,6 +247,7 @@ const MyChallengeMain = () => {
                     ? 'PENDING'
                     : challenge.approvalStatus,
               }}
+              status={activeTab}
             />
           ))
         )}

--- a/src/shared/components/card/Card.tsx
+++ b/src/shared/components/card/Card.tsx
@@ -119,7 +119,7 @@ export const Card = ({
                   : ButtonCategory.VIEW_ORIGINAL
               }
               onClick={() => handleRoute()}
-              size="py-2 pl-4 pr-1"
+              size="py-2 pl-6 "
             >
               {status === 'participating' ? '도전 계속하기' : '내 작업물 보기'}
             </Button>

--- a/src/shared/components/form/ChallengeForm.tsx
+++ b/src/shared/components/form/ChallengeForm.tsx
@@ -82,8 +82,8 @@ const ChallengeForm = ({
               message: '제목은 최소 2자 이상이어야 합니다.',
             },
             maxLength: {
-              value: 15,
-              message: '제목은 최대 15자 이하여야 합니다.',
+              value: 30,
+              message: '제목은 최대 30자 이하여야 합니다.',
             },
           }}
           errorMessage={_errors.title?.message}


### PR DESCRIPTION
## 📌 개요

- 카드 버튼 수정, 챌린지 생성/수정시 수정, 파비콘 추가

## ✨ 주요 변경 사항

- 마이첼린지 페이지 버튼 오류 수정
- 챌린지 생성/수정시 제목제한 30
- 파비콘 추가

## 🌐 공유 사항(다른 팀원들도 알아두어야 할 것들)

- 

## 🔗 관련 이슈

- 

## 📸 스크린샷

- 
